### PR TITLE
Supporting Mac

### DIFF
--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -135,6 +135,10 @@ if (('IBM_DB_HOME' not in os.environ) and ('IBM_DB_DIR' not in os.environ) and (
         else:
             cliFileName = 'nt32_odbc_cli.zip'
             arch_ = '32'
+    elif('darwin' in sys.platform and is64Bit):
+        os_ = 'mac'
+        cliFileName = 'macos64_odbc_cli.tar.gz'
+        arch_ = 'x86_64'
     else:
         sys.stdout.write("Not a known platform for python ibm_db . Contact opendev@us.ibm.com")
         sys.stdout.flush()
@@ -204,7 +208,7 @@ if not prebuildIbmdbPYD and not os.path.isdir(ibm_db_include):
     
 library = ['db2']
 package_data = { 'tests': [ '*.png', '*.jpg']}
-data_files = [ ('', ['./README']),
+data_files = [ ('', ['./README.md']),
                ('', ['./CHANGES']),
                ('', ['./LICENSE']) ]
 

--- a/IBM_DB/ibm_db_django/setup.py
+++ b/IBM_DB/ibm_db_django/setup.py
@@ -54,7 +54,7 @@ setup (
                          'Operating System :: POSIX :: Linux',
                          'Operating System :: MacOS',
                          'Topic :: Database :: Front-Ends'],
-    data_files        = [ ('', ['./README']),
+    data_files        = [ ('', ['./README.md']),
                           ('', ['./CHANGES']),
                           ('', ['./LICENSE']) ],
     zip_safe          = False,


### PR DESCRIPTION
This package doesn't work on mac and there is also an issue with the name of README.md when running python setup.py install.

EDIT:

Note: for macs you also need to `export DYLD_LIBRARY_PATH=<location>/clidriver/lib:<location>/clidriver/lib/icc`, where <location> is the installed location of the clidriver, and this needs to be done every time before you can run `import ibm_db`.