### PR TITLE
inc/dec bound Python objects and ensure cache is cleared properly

### DIFF
--- a/IBM_DB/ibm_db/tests/test_312_CacheBoundParameters.py
+++ b/IBM_DB/ibm_db/tests/test_312_CacheBoundParameters.py
@@ -36,7 +36,7 @@ class IbmDbTestCase(unittest.TestCase):
         ibm_db.bind_param(stmt, i, Wrapper(p))
       
       if ibm_db.execute(stmt):
-        print("Executing parameters")
+        print("Executing statement")
         ibm_db.execute(stmt)
 
         # force the cache to be unbound
@@ -50,7 +50,7 @@ class IbmDbTestCase(unittest.TestCase):
 #__END__
 #__LUW_EXPECTED__
 #Binding parameters
-#Executing parameters
+#Executing statement
 #Wrapper(STG) being deleted
 #Wrapper(Systems & Technology) being deleted
 #Wrapper(123456) being deleted
@@ -58,7 +58,7 @@ class IbmDbTestCase(unittest.TestCase):
 #Wrapper(Fiji) being deleted
 #__ZOS_EXPECTED__
 #Binding parameters
-#Executing parameters
+#Executing statement
 #Wrapper(STG) being deleted
 #Wrapper(Systems & Technology) being deleted
 #Wrapper(123456) being deleted
@@ -66,7 +66,7 @@ class IbmDbTestCase(unittest.TestCase):
 #Wrapper(Fiji) being deleted
 #__SYSTEMI_EXPECTED__
 #Binding parameters
-#Executing parameters
+#Executing statement
 #Wrapper(STG) being deleted
 #Wrapper(Systems & Technology) being deleted
 #Wrapper(123456) being deleted
@@ -74,7 +74,7 @@ class IbmDbTestCase(unittest.TestCase):
 #Wrapper(Fiji) being deleted
 #__IDS_EXPECTED__
 #Binding parameters
-#Executing parameters
+#Executing statement
 #Wrapper(STG) being deleted
 #Wrapper(Systems & Technology) being deleted
 #Wrapper(123456) being deleted

--- a/IBM_DB/ibm_db/tests/test_312_CacheBoundParameters.py
+++ b/IBM_DB/ibm_db/tests/test_312_CacheBoundParameters.py
@@ -1,0 +1,82 @@
+#
+#  Licensed Materials - Property of IBM
+#
+#  (c) Copyright IBM Corp. 2016
+#
+
+from __future__ import print_function
+import unittest, sys
+import ibm_db
+import config
+from testfunctions import IbmDbTestFunctions
+
+class Wrapper(str):
+  def __del__(self):
+    print("Wrapper(" + self + ") being deleted")
+
+class IbmDbTestCase(unittest.TestCase):
+
+  def test_312_CacheBoundParameters(self):
+    obj = IbmDbTestFunctions()
+    obj.assert_expect(self.run_test_312)
+  
+  def run_test_312(self):
+    conn = ibm_db.connect(config.database, config.user, config.password)
+
+    ibm_db.autocommit(conn, ibm_db.SQL_AUTOCOMMIT_OFF)
+    
+    query = "INSERT INTO department (deptno, deptname, mgrno, admrdept, location) VALUES (?, ?, ?, ?, ?)"
+    
+    if conn:
+      stmt = ibm_db.prepare(conn, query)
+      params = ['STG', 'Systems & Technology', '123456', 'RSF', 'Fiji']
+
+      print("Binding parameters")
+      for i,p in enumerate(params, 1):
+        ibm_db.bind_param(stmt, i, Wrapper(p))
+      
+      if ibm_db.execute(stmt):
+        print("Executing parameters")
+        ibm_db.execute(stmt)
+
+        # force the cache to be unbound
+        for i,p in enumerate(params, 1):
+          ibm_db.bind_param(stmt, i, p)
+        
+        ibm_db.rollback(conn)
+      else:
+        print("Connection failed.")
+
+#__END__
+#__LUW_EXPECTED__
+#Binding parameters
+#Executing parameters
+#Wrapper(STG) being deleted
+#Wrapper(Systems & Technology) being deleted
+#Wrapper(123456) being deleted
+#Wrapper(RSF) being deleted
+#Wrapper(Fiji) being deleted
+#__ZOS_EXPECTED__
+#Binding parameters
+#Executing parameters
+#Wrapper(STG) being deleted
+#Wrapper(Systems & Technology) being deleted
+#Wrapper(123456) being deleted
+#Wrapper(RSF) being deleted
+#Wrapper(Fiji) being deleted
+#__SYSTEMI_EXPECTED__
+#Binding parameters
+#Executing parameters
+#Wrapper(STG) being deleted
+#Wrapper(Systems & Technology) being deleted
+#Wrapper(123456) being deleted
+#Wrapper(RSF) being deleted
+#Wrapper(Fiji) being deleted
+#__IDS_EXPECTED__
+#Binding parameters
+#Executing parameters
+#Wrapper(STG) being deleted
+#Wrapper(Systems & Technology) being deleted
+#Wrapper(123456) being deleted
+#Wrapper(RSF) being deleted
+#Wrapper(Fiji) being deleted


### PR DESCRIPTION
When binding a Python object to a parameter, we store a pointer to
the Python object, but we do not increment the refcount. If the
object loses all references, it will be automatically cleaned up
by the interpreter and the results of our execute are undeterminable
and can result in Segmentation Faults.

Additionally, while adding this code I found that code to clear the
param cache was in various places and was inconsistent, resulting
in possible memory leaks due to unfreed memory. This has been
consolidated to a new function: _python_ibm_db_clear_param_cache

Fixes #216