### PR TITLE
Possible to set SCHEMA on connect

### DIFF
--- a/IBM_DB/ibm_db_django/ibm_db_django/base.py
+++ b/IBM_DB/ibm_db_django/ibm_db_django/base.py
@@ -268,7 +268,9 @@ class DatabaseWrapper( BaseDatabaseWrapper ):
             return self.databaseWrapper._cursor( self.connection )
             
         def init_connection_state( self ):
-            pass
+            if ( self.settings_dict.keys() ).__contains__( 'SCHEMA' ):
+                with self.cursor() as cursor:
+                    cursor.execute('SET CURRENT_SCHEMA = %s', (self.settings_dict['SCHEMA'], ))
         
         def is_usable(self):
             if self.databaseWrapper.is_active( self.connection ):


### PR DESCRIPTION
So my DB2 uses the username as default schema after the connection is established. And I needed a way to change that in django.

This makes it possible to use an optional SCHEMA key in your database settings dict.
