### PR TITLE
Removed DatabaseFeatures.can_introspect_max_length.

### DIFF
--- a/IBM_DB/ibm_db_django/ibm_db_django/base.py
+++ b/IBM_DB/ibm_db_django/ibm_db_django/base.py
@@ -116,7 +116,6 @@ class DatabaseFeatures( BaseDatabaseFeatures ):
     can_introspect_positive_integer_field = False
     can_introspect_small_integer_field = True
     can_introspect_null = True
-    can_introspect_max_length = True
     can_introspect_ip_address_field = False
     can_introspect_time_field = True
     


### PR DESCRIPTION
Unused (always True) (see [3e43d24](https://github.com/django/django/commit/3e43d24ad36d45cace57e6a7efd34638577ae74) and [PR](https://github.com/django/django/pull/7712)).