### PR TITLE
process unique persistent connections

### DIFF
--- a/IBM_DB/ibm_db/ibm_db.c
+++ b/IBM_DB/ibm_db/ibm_db.c
@@ -1164,12 +1164,13 @@ static PyObject *_python_ibm_db_connect_helper( PyObject *self, PyObject *args, 
 		passwordObj = PyUnicode_FromObject(passwordObj);
 
 		/* Check if we already have a connection for this userID & database 
-		* combination
+		* combination in this process.
 		*/ 
 		if (isPersistent) {
 			hKey = PyUnicode_Concat(StringOBJ_FromASCII("__ibm_db_"), uidObj);
 			hKey = PyUnicode_Concat(hKey, databaseObj);
 			hKey = PyUnicode_Concat(hKey, passwordObj);
+			hKey = PyUnicode_Concat(hKey, PyUnicode_FromFormat("%zu", getpid()));
 
 			entry = PyDict_GetItem(persistent_list, hKey);
 


### PR DESCRIPTION
Connection objects can not be shared across processes.  We hit an issue where a persistent connection was established in one process prior to forking a sub-process and the sub-process was trying to re-use the same persistent connection object.  These are long running processes performing many database operations so avoiding regular connect() overhead is worthwhile.  A simple fix seems to be adding the process id to the persistent connection dictionary key such that each process gets a unique connection.  This change has been tested on macOS 10.13.1 and Ubuntu 16.04.3 LTS with no detrimental effects found.  

Potential issues:
*  is getpid() portable enough?  We do not have access to a Windows machine for testing -- is there some other process identifier that would be better?