### PR TITLE
Remove reused = 1 outside connection check

### DIFF
--- a/IBM_DB/ibm_db/ibm_db.c
+++ b/IBM_DB/ibm_db/ibm_db.c
@@ -1186,7 +1186,6 @@ static PyObject *_python_ibm_db_connect_helper( PyObject *self, PyObject *args, 
 					reused = 1;
 				} /* else will re-connect since connection is dead */
 #endif /* PASE */
-				reused = 1;
 			}
 		} else {
 			/* Need to check for max pconnections? */


### PR DESCRIPTION
Set reused=1 only if SQL_SUCCESS and conn_alive are true. Was setting reused=1 regardless of whether the healthy connection checks were true or not.