### PR TITLE
removed unnecessary check when adding M2M field

### DIFF
--- a/IBM_DB/ibm_db_django/ibm_db_django/schemaEditor.py
+++ b/IBM_DB/ibm_db_django/ibm_db_django/schemaEditor.py
@@ -527,18 +527,8 @@ class DB2SchemaEditor(BaseDatabaseSchemaEditor):
         field._unique = False
         
         super(DB2SchemaEditor, self).add_field(model, field)
-        if( djangoVersion[0:2] < ( 1, 9 ) ):
-            if field.rel is not None and hasattr(field.rel,'through'):
-                rel_condition = field.rel.through._meta.auto_created
-            else:
-                rel_condition = False
-        else:
-            if field.remote_field is not None and hasattr(field.remote_field,'through'):
-                rel_condition = field.remote_field.through._meta.auto_created
-            else:
-                rel_condition = False
-                
-        if isinstance(field, ManyToManyField) and rel_condition:
+        
+        if isinstance(field, ManyToManyField):
             return
         else:
             self._reorg_tables()


### PR DESCRIPTION
The implementation brought up an Exception when adding a new M2M-field with selfwritten through-Model. 

That happened because _auto_create_ is _False_ in this case what results in _rel_condition=False_. 
Because it is a notnull-field it was trying to alter the column to _not null_ throwing 

"Column, attribute, or period [M2M-field-name] is not defined in [table-name]".

All the logic that determines if it is a M2M-field that has to be auto-/manually created is already done in the _super().add_field_ call. A M2M-field never adds a new column but always a new table. It does not matter if it's auto-/manually created. So all the notnull, unique and p_key stuff is never relevant for Many2Many.