### PR TITLE
 Fix bug in setup.py where wrong cli file could be downloaded

### DIFF
--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -126,7 +126,7 @@ if (('IBM_DB_HOME' not in os.environ) and ('IBM_DB_DIR' not in os.environ) and (
                 cliFileName = 'sunamd64_odbc_cli.tar.gz'
             else:
                 cliFileName = 'sunamd32_odbc_cli.tar.gz'
-        elif ('SPARC' in os.uname()[4]):
+        elif ('sun4' in os.uname()[4]):
             arch_ = 'SUNW'
             if is64Bit:
                 cliFileName = 'sun64_odbc_cli.tar.gz'

--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -40,13 +40,6 @@ else:
     libDir = 'lib32'
     sys.stdout.write("Detected 32-bit Python\n")
 
-# check if val exists in list
-def _checkOSList(list, val):
-    for s in list:
-        if ( val in s):
-            return True
-    return False
-
 # defining extension    
 def _ext_modules(include_dir, library, lib_dir, runtime_dir=None):
     ext_args = dict(include_dirs = [include_dir],
@@ -98,12 +91,12 @@ if (('IBM_DB_HOME' not in os.environ) and ('IBM_DB_DIR' not in os.environ) and (
             cliFileName = 'aix32_odbc_cli.tar.gz'
     elif ('linux' in sys.platform):
         os_ = 'linux'
-        if (_checkOSList(os.uname(),'ppc64le')):	
+        if ('ppc64le' in os.uname()[4]):	
             os_ = 'ppc64le'
             if is64Bit:
                 cliFileName = 'ppc64le_odbc_cli.tar.gz'
                 arch_ = 'ppc64le'
-        elif (_checkOSList(os.uname(),'ppc')):	
+        elif ('ppc' in os.uname()[4]):	
             os_ = 'ppc'
             if is64Bit:
                 cliFileName = 'ppc64_odbc_cli.tar.gz'
@@ -111,14 +104,14 @@ if (('IBM_DB_HOME' not in os.environ) and ('IBM_DB_DIR' not in os.environ) and (
             else:
                 cliFileName = 'ppc32_odbc_cli.tar.gz'
                 arch_ = 'ppc*'
-        elif (_checkOSList(os.uname(),'86')): # todo needs to search in list
+        elif ('86' in os.uname()[4]): # todo needs to search in list
             if is64Bit:
                 cliFileName = 'linuxx64_odbc_cli.tar.gz'
                 arch_ = 'x86_64'    
             else:
                 cliFileName = 'linuxia32_odbc_cli.tar.gz'
                 arch_ = 'i686'
-        elif (_checkOSList(os.uname(),'390')):
+        elif ('390' in os.uname()[4]):
             if is64Bit:
                 cliFileName = 's390x64_odbc_cli.tar.gz'
                 arch_ = 's390x'
@@ -127,13 +120,13 @@ if (('IBM_DB_HOME' not in os.environ) and ('IBM_DB_DIR' not in os.environ) and (
                 arch_ = 's390'
     elif ('sunos' in sys.platform):
         os_ = 'solaris*'
-        if ('i86pc' in os.uname()):
+        if ('i86pc' in os.uname()[4]):
             arch_ = 'i86pc'
             if is64Bit:
                 cliFileName = 'sunamd64_odbc_cli.tar.gz'
             else:
                 cliFileName = 'sunamd32_odbc_cli.tar.gz'
-        elif ('SPARC' in os.uname()):
+        elif ('SPARC' in os.uname()[4]):
             arch_ = 'SUNW'
             if is64Bit:
                 cliFileName = 'sun64_odbc_cli.tar.gz'

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Provides Python, Django and SQLAlchemy support for IBM DB2 and Informix
 
 [Downloads](#downloads)
 
-[Latest Updates](#latest updates)
+[Latest Updates](#latest-updates)
 
 [Support](#support)
 
-[Contributing to the ibm_db python project](#contributing to the ibm_db python project)
+[Contributing to the ibm_db python project](#contributing-to-the-ibm_db-python-project)
 
 <a name='components'></a>
 ## Components (Python Eggs)
@@ -44,7 +44,7 @@ Use following pypi web location for downloading source code and binaries
  3. **ibm_db_sa**: https://pypi.python.org/pypi/ibm_db_sa .
  4. **ibm_db_alembic**: https://pypi.python.org/pypi/ibm_db_alembic .
 
-<a name='latest updates'></a>
+<a name='latest-updates'></a>
 ## Latest Updates
 
 ### *Support for Alembic*
@@ -69,7 +69,7 @@ Use following pypi web location for downloading source code and binaries
  * Google Group: http://groups.google.com/group/ibm_db
    
  
-<a name='contributing to the ibm_db python project'></a>
+<a name='contributing-to-the-ibm_db-python-project'></a>
 ## Contributing to the ibm_db python project
 
 See [CONTRIBUTING](https://github.com/ibmdb/python-ibmdb/blob/master/contributing/CONTRIBUTING.md)


### PR DESCRIPTION
I work for IBM; this work is theirs, so I accept the contributor guidelines.

Anyway, there’s a bug in the setup for ibm_db.  Specifically, when you’re trying to install the command line library.  You have function that looks through everything that’s returned from os.uname() to determine which one to download.  That function looks through all the items returned, which includes (sysname,nodename, release, version, machine).  The problem is that when you’re checking to determine which libraries to download for linux, you look at all those fields, and right now, the release string for RHEL zLinux is '3.10.0-862.el7.s390x’, so if you try installing ibm_db on zLinux, it downloads the cli_libraries for the x86 platform and the install fails.  What I’m proposing you do instead is only look at the machine field to determine the architecture.  I don’t have access to all those types of machines to validate that this is the correct solution, but it does work for zLinux.  I’m assuming you have a place you can validate the other platforms.