### PR TITLE
Ensure generated tarballs include IBM certificates

### DIFF
--- a/IBM_DB/ibm_db/MANIFEST.in
+++ b/IBM_DB/ibm_db/MANIFEST.in
@@ -1,7 +1,9 @@
 include ibm_db.h ibm_db.c
 include CHANGES LICENSE README.md
+include config.py.sample
 recursive-include tests *.py *.png *.jpg 
 include MANIFEST.in
 recursive-include clidriver *
 recursive-include ibm_db_dlls *
 recursive-include certs *
+exclude config.py

--- a/IBM_DB/ibm_db/MANIFEST.in
+++ b/IBM_DB/ibm_db/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include tests *.py *.png *.jpg
 include MANIFEST.in
 recursive-include clidriver *
 recursive-include ibm_db_dlls *
+recursive-include certs *

--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -242,7 +242,7 @@ data_files = [ ('', ['./README.md']),
                ('', ['./CHANGES']),
                ('', ['./LICENSE']) ]
 
-modules = ['config', 'ibm_db_dbi', 'testfunctions', 'tests']
+modules = ['ibm_db_dbi', 'testfunctions', 'tests']
 ext_modules = _ext_modules(ibm_db_include, library, ibm_db_lib, ibm_db_lib_runtime)
 
 if (sys.platform[0:3] == 'win'):


### PR DESCRIPTION
Follow-on to #367 

The certificates need to get added to the MANIFEST or they won't be shipped in the source distribution tarball generated by `python setup.py sdist`

In addition, `config.py` can contain sensitive information. It should not be shipped or installed, but instead use `config.py.sample`.