### PR TITLE
ibm_db_dbi.py: Old style exceptions --> new style for Python 3

### DIFF
--- a/IBM_DB/ibm_db/ibm_db_dbi.py
+++ b/IBM_DB/ibm_db/ibm_db_dbi.py
@@ -447,7 +447,7 @@ def _server_connect(dsn, user='', password='', host=''):
         dsn = dsn + "PWD=" + password + ";"
     try:
         conn = ibm_db.connect(dsn, '', '')
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
 
     return conn
@@ -466,12 +466,12 @@ def createdb(database, dsn, user='', password='', host='', codeset='', mode=''):
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.createdb(conn, database, codeset, mode)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -488,12 +488,12 @@ def dropdb(database, dsn, user='', password='', host=''):
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.dropdb(conn, database)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -512,12 +512,12 @@ def recreatedb(database, dsn, user='', password='', host='', codeset='', mode=''
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.recreatedb(conn, database, codeset, mode)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -536,12 +536,12 @@ def createdbNX(database, dsn, user='', password='', host='', codeset='', mode=''
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.createdbNX(conn, database, codeset, mode)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -591,7 +591,7 @@ def connect(dsn, user='', password='', host='', database='', conn_options=None):
     try:
         conn = ibm_db.connect(dsn, '', '', conn_options)
         ibm_db.set_option(conn, {SQL_ATTR_CURRENT_SCHEMA : user}, 1)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
 
     return Connection(conn)
@@ -641,7 +641,7 @@ def pconnect(dsn, user='', password='', host='', database='', conn_options=None)
     try:
         conn = ibm_db.pconnect(dsn, '', '', conn_options)
         ibm_db.set_option(conn, {SQL_ATTR_CURRENT_SCHEMA : user}, 1)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
 
     return Connection(conn)
@@ -693,7 +693,7 @@ class Connection(object):
                                      "connection is no longer active.")
             else:
                 return_value = ibm_db.close(self.conn_handler)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         self.conn_handler = None
         for index in range(len(self._cursor_list)):
@@ -712,7 +712,7 @@ class Connection(object):
         """
         try:
             return_value = ibm_db.commit(self.conn_handler)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return return_value
 
@@ -723,7 +723,7 @@ class Connection(object):
         """
         try:
             return_value = ibm_db.rollback(self.conn_handler)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return return_value
 
@@ -760,7 +760,7 @@ class Connection(object):
                 self.FIX_RETURN_TYPE = 1
             else:
                 self.FIX_RETURN_TYPE = 0
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return self.FIX_RETURN_TYPE
 
@@ -774,7 +774,7 @@ class Connection(object):
                 is_set = ibm_db.set_option(self.conn_handler, {SQL_ATTR_AUTOCOMMIT : SQL_AUTOCOMMIT_ON}, 1)
             else:
                 is_set = ibm_db.set_option(self.conn_handler, {SQL_ATTR_AUTOCOMMIT : SQL_AUTOCOMMIT_OFF}, 1)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return is_set
 
@@ -786,7 +786,7 @@ class Connection(object):
         self.current_schema = schema_name
         try:
             is_set = ibm_db.set_option(self.conn_handler, {SQL_ATTR_CURRENT_SCHEMA : schema_name}, 1)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return is_set
 
@@ -798,7 +798,7 @@ class Connection(object):
             conn_schema = ibm_db.get_option(self.conn_handler, SQL_ATTR_CURRENT_SCHEMA, 1)
             if conn_schema is not None and conn_schema != '':
                 self.current_schema = conn_schema
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return self.current_schema
 
@@ -810,7 +810,7 @@ class Connection(object):
             server_info = []
             server_info.append(self.dbms_name)
             server_info.append(self.dbms_ver)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return tuple(server_info)
 
@@ -838,7 +838,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -876,7 +876,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -910,7 +910,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -948,7 +948,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -999,7 +999,7 @@ class Connection(object):
                             column['COLUMN_NAME'] = column['COLUMN_NAME'].lower()
                             include_columns.append(column)
                     result = include_columns
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -1077,7 +1077,7 @@ class Cursor(object):
                                              self.stmt_handler, column_index))
 
                 self.__description.append(column_desc)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
 
@@ -1145,7 +1145,7 @@ class Cursor(object):
             raise self.messages[len(self.messages) - 1]
         try:
             return_value = ibm_db.free_stmt(self.stmt_handler)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
         self.stmt_handler = None
@@ -1173,13 +1173,13 @@ class Cursor(object):
 
             try:
                 result = ibm_db.callproc(self.conn_handler, procname,parameters)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         else:
             try:
                 result = ibm_db.callproc(self.conn_handler, procname)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         return result
@@ -1220,7 +1220,7 @@ class Cursor(object):
 
         try:
             self.stmt_handler = ibm_db.prepare(self.conn_handler, operation)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
 
@@ -1233,7 +1233,7 @@ class Cursor(object):
         self._result_set_produced = False
         try:
             num_columns = ibm_db.num_fields(self.stmt_handler)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
         if not num_columns:
@@ -1263,7 +1263,7 @@ class Cursor(object):
                     if ibm_db.stmt_errormsg() is not None:
                         self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                         raise self.messages[len(self.messages) - 1]
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         else:
@@ -1276,7 +1276,7 @@ class Cursor(object):
                     if ibm_db.stmt_errormsg() is not None:
                         self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                         raise self.messages[len(self.messages) - 1]
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         return return_value
@@ -1288,14 +1288,14 @@ class Cursor(object):
         if not self._result_set_produced:
             try:
                 counter = ibm_db.num_rows(self.stmt_handler)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
             self.__rowcount = counter
         elif self._is_scrollable_cursor:
             try:
                 counter = ibm_db.get_num_result(self.stmt_handler)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
             if counter >= 0:
@@ -1328,7 +1328,7 @@ class Cursor(object):
                 if ibm_db.stmt_errormsg() is not None:
                     self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                     raise self.messages[len(self.messages) - 1]
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
         return identity_val
@@ -1407,7 +1407,7 @@ class Cursor(object):
                 if ibm_db.stmt_errormsg() is not None:
                     self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                     raise self.messages[len(self.messages) - 1]
-        except Exception, inst:
+        except Exception as inst:
             self._set_rowcount()
             self.messages.append(Error(inst))
             raise self.messages[len(self.messages) - 1]
@@ -1432,7 +1432,7 @@ class Cursor(object):
               (fetch_size != -1 and rows_fetched < fetch_size):
             try:
                 row = ibm_db.fetch_tuple(self.stmt_handler)
-            except Exception, inst:
+            except Exception as inst:
                 if ibm_db.stmt_errormsg() is not None:
                     self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                 else:
@@ -1504,7 +1504,7 @@ class Cursor(object):
             self.__description = None
             self._all_stmt_handlers.append(self.stmt_handler)
             self.stmt_handler = ibm_db.next_result(self._all_stmt_handlers[0])
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
 
@@ -1543,7 +1543,7 @@ class Cursor(object):
                             row_list = list(row)
                         row_list[index] = decimal.Decimal(str(row[index]).replace(",", "."))
 
-                except Exception, inst:
+                except Exception as inst:
                     self.messages.append(DataError("Data type format error: "+ str(inst)))
                     raise self.messages[len(self.messages) - 1]
         if row_list is None:


### PR DESCRIPTION
Old style exceptions are ___syntax errors___ in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/ibmdb/python-ibmdb on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./IBM_DB/ibm_db/ibm_db_dbi.py:450:21: E999 SyntaxError: invalid syntax
    except Exception, inst:
                    ^
./IBM_DB/ibm_db/tests/test_264_InsertRetrieveBIGINTTypeColumn.py:61:44: F821 undefined name 'long'
                    print(type(data[0]) is long)
                                           ^
./IBM_DB/ibm_db/tests/test_264_InsertRetrieveBIGINTTypeColumn.py:62:44: F821 undefined name 'long'
                    print(type(data[1]) is long)
                                           ^
./IBM_DB/ibm_db/tests/test_264_InsertRetrieveBIGINTTypeColumn.py:63:44: F821 undefined name 'long'
                    print(type(data[2]) is long)
                                           ^
./IBM_DB/ibm_db/tests/test_251_FreeResult_02.py:29:37: F821 undefined name 'result99'
            r3 = ibm_db.free_result(result99)
                                    ^
1     E999 SyntaxError: invalid syntax
4     F821 undefined name 'result99'
5
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree