### PR TITLE
Simplify by defining "long" in Python 3

### DIFF
--- a/IBM_DB/ibm_db/tests/test_264_InsertRetrieveBIGINTTypeColumn.py
+++ b/IBM_DB/ibm_db/tests/test_264_InsertRetrieveBIGINTTypeColumn.py
@@ -5,11 +5,16 @@
 #
 
 from __future__ import print_function
-import sys
 import unittest
 import ibm_db
 import config
 from testfunctions import IbmDbTestFunctions
+
+try:
+    long        # Python 3
+except NameError:
+    long = int  # Python 3
+
 
 class IbmDbTestCase(unittest.TestCase):
 
@@ -53,14 +58,9 @@ class IbmDbTestCase(unittest.TestCase):
                 print(data[1])
                 print(data[2])
                 print(data[3])
-                if sys.version_info >= (3, ):
-                    print(type(data[0]) is int)
-                    print(type(data[1]) is int)
-                    print(type(data[2]) is int)
-                else:
-                    print(type(data[0]) is long)
-                    print(type(data[1]) is long)
-                    print(type(data[2]) is long)
+                print(type(data[0]) is long)
+                print(type(data[1]) is long)
+                print(type(data[2]) is long)
                 data = ibm_db.fetch_both(stmt)
 
             ibm_db.close(conn)


### PR DESCRIPTION
Follows Python porting best practice [__use feature detection instead of version detection__](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

DCO 1.1 Signed-off-by: Christian Clauss  cclauss@me.com