### PR TITLE
ibm_db_dbi.py: Fix Python 3 syntax error

### DIFF
--- a/IBM_DB/ibm_db/ibm_db_dbi.py
+++ b/IBM_DB/ibm_db/ibm_db_dbi.py
@@ -35,6 +35,11 @@ else:
 import ibm_db
 __version__ = ibm_db.__version__
 
+try:
+    basestring  # Python 2
+except NameError:
+    basestring = str  # Python 3
+
 # Constants for specifying database connection options.
 SQL_ATTR_AUTOCOMMIT = ibm_db.SQL_ATTR_AUTOCOMMIT
 SQL_ATTR_CURRENT_SCHEMA = ibm_db.SQL_ATTR_CURRENT_SCHEMA
@@ -447,7 +452,7 @@ def _server_connect(dsn, user='', password='', host=''):
         dsn = dsn + "PWD=" + password + ";"
     try:
         conn = ibm_db.connect(dsn, '', '')
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
 
     return conn


### PR DESCRIPTION
Old style exceptions are syntax errors on Python 3 but new style exceptions work as expected on both Python 2 and Python 3.

Also define __basestring__ in Python 3 where it was removed in favor of __str__.