### PR TITLE
Travis CI: Add Python 3.8 and drop 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,10 @@
 language: python
-
-matrix:
-    include:
-        - python: 2.7
-          dist: trusty
-          sudo: false
-        - python: 3.4
-          dist: trusty
-          sudo: false
-        - python: 3.5
-          dist: trusty
-          sudo: false
-        - python: 3.6
-          dist: trusty
-          sudo: false
-        - python: 3.7
-          dist: xenial
-          sudo: true
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 
 install:
 - docker pull ibmcom/db2express-c


### PR DESCRIPTION
Align with current CPython releases https://devguide.python.org/#branchstatus

DCO 1.1 Signed-off-by: Christian Clauss <cclauss@me.com>