### PR TITLE
Fix Python 3 syntax errors in ibm_db_dbi.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,15 @@
 language: python
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 
-matrix:
-    include:
-        - python: 2.7
-          dist: trusty
-          sudo: false
-        - python: 3.4
-          dist: trusty
-          sudo: false
-        - python: 3.5
-          dist: trusty
-          sudo: false
-        - python: 3.6
-          dist: trusty
-          sudo: false
-        - python: 3.7
-          dist: xenial
-          sudo: true
-
+before_install:
+- pip install --upgrade pip
+- pip install flake8  # find Python syntax errors and undefined names
+- flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 install:
 - docker pull ibmcom/db2express-c
 - docker run --name db2  -p 50000:50000 -e DB2INST1_PASSWORD=password -e LICENSE=accept -d ibmcom/db2express-c db2start
@@ -45,5 +37,5 @@ script:
 - python tests.py
 
 notifications:
-  email: 
+  email:
     - skauser@rocketsoftware.com

--- a/IBM_DB/ibm_db/ibm_db_dbi.py
+++ b/IBM_DB/ibm_db/ibm_db_dbi.py
@@ -32,6 +32,13 @@ if sys.version_info < (3, ):
 else:
     exception = Exception
 
+try:
+    basestring  # Python 2
+    long
+except NameError:
+    basestring = str  # Python 3
+    long = int
+
 import ibm_db
 __version__ = ibm_db.__version__
 
@@ -447,7 +454,7 @@ def _server_connect(dsn, user='', password='', host=''):
         dsn = dsn + "PWD=" + password + ";"
     try:
         conn = ibm_db.connect(dsn, '', '')
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
 
     return conn
@@ -466,12 +473,12 @@ def createdb(database, dsn, user='', password='', host='', codeset='', mode=''):
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.createdb(conn, database, codeset, mode)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -488,12 +495,12 @@ def dropdb(database, dsn, user='', password='', host=''):
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.dropdb(conn, database)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -512,12 +519,12 @@ def recreatedb(database, dsn, user='', password='', host='', codeset='', mode=''
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.recreatedb(conn, database, codeset, mode)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -536,12 +543,12 @@ def createdbNX(database, dsn, user='', password='', host='', codeset='', mode=''
     conn = _server_connect(dsn, user=user, password=password, host=host)
     try:
         return_value = ibm_db.createdbNX(conn, database, codeset, mode)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
     finally:
         try:
             ibm_db.close(conn)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
     return return_value
@@ -591,7 +598,7 @@ def connect(dsn, user='', password='', host='', database='', conn_options=None):
     try:
         conn = ibm_db.connect(dsn, '', '', conn_options)
         ibm_db.set_option(conn, {SQL_ATTR_CURRENT_SCHEMA : user}, 1)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
 
     return Connection(conn)
@@ -641,7 +648,7 @@ def pconnect(dsn, user='', password='', host='', database='', conn_options=None)
     try:
         conn = ibm_db.pconnect(dsn, '', '', conn_options)
         ibm_db.set_option(conn, {SQL_ATTR_CURRENT_SCHEMA : user}, 1)
-    except Exception, inst:
+    except Exception as inst:
         raise _get_exception(inst)
 
     return Connection(conn)
@@ -693,7 +700,7 @@ class Connection(object):
                                      "connection is no longer active.")
             else:
                 return_value = ibm_db.close(self.conn_handler)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         self.conn_handler = None
         for index in range(len(self._cursor_list)):
@@ -712,7 +719,7 @@ class Connection(object):
         """
         try:
             return_value = ibm_db.commit(self.conn_handler)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return return_value
 
@@ -723,7 +730,7 @@ class Connection(object):
         """
         try:
             return_value = ibm_db.rollback(self.conn_handler)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return return_value
 
@@ -760,7 +767,7 @@ class Connection(object):
                 self.FIX_RETURN_TYPE = 1
             else:
                 self.FIX_RETURN_TYPE = 0
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return self.FIX_RETURN_TYPE
 
@@ -774,7 +781,7 @@ class Connection(object):
                 is_set = ibm_db.set_option(self.conn_handler, {SQL_ATTR_AUTOCOMMIT : SQL_AUTOCOMMIT_ON}, 1)
             else:
                 is_set = ibm_db.set_option(self.conn_handler, {SQL_ATTR_AUTOCOMMIT : SQL_AUTOCOMMIT_OFF}, 1)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return is_set
 
@@ -786,7 +793,7 @@ class Connection(object):
         self.current_schema = schema_name
         try:
             is_set = ibm_db.set_option(self.conn_handler, {SQL_ATTR_CURRENT_SCHEMA : schema_name}, 1)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return is_set
 
@@ -798,7 +805,7 @@ class Connection(object):
             conn_schema = ibm_db.get_option(self.conn_handler, SQL_ATTR_CURRENT_SCHEMA, 1)
             if conn_schema is not None and conn_schema != '':
                 self.current_schema = conn_schema
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return self.current_schema
 
@@ -810,7 +817,7 @@ class Connection(object):
             server_info = []
             server_info.append(self.dbms_name)
             server_info.append(self.dbms_ver)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
         return tuple(server_info)
 
@@ -838,7 +845,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -876,7 +883,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -910,7 +917,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -948,7 +955,7 @@ class Connection(object):
                 i += 1
                 row = ibm_db.fetch_assoc(stmt)
             ibm_db.free_result(stmt)
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -999,7 +1006,7 @@ class Connection(object):
                             column['COLUMN_NAME'] = column['COLUMN_NAME'].lower()
                             include_columns.append(column)
                     result = include_columns
-        except Exception, inst:
+        except Exception as inst:
             raise _get_exception(inst)
 
         return result
@@ -1077,7 +1084,7 @@ class Cursor(object):
                                              self.stmt_handler, column_index))
 
                 self.__description.append(column_desc)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
 
@@ -1145,7 +1152,7 @@ class Cursor(object):
             raise self.messages[len(self.messages) - 1]
         try:
             return_value = ibm_db.free_stmt(self.stmt_handler)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
         self.stmt_handler = None
@@ -1173,13 +1180,13 @@ class Cursor(object):
 
             try:
                 result = ibm_db.callproc(self.conn_handler, procname,parameters)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         else:
             try:
                 result = ibm_db.callproc(self.conn_handler, procname)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         return result
@@ -1220,7 +1227,7 @@ class Cursor(object):
 
         try:
             self.stmt_handler = ibm_db.prepare(self.conn_handler, operation)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
 
@@ -1233,7 +1240,7 @@ class Cursor(object):
         self._result_set_produced = False
         try:
             num_columns = ibm_db.num_fields(self.stmt_handler)
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
         if not num_columns:
@@ -1265,7 +1272,7 @@ class Cursor(object):
                     if ibm_db.stmt_errormsg() is not None:
                         self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                         raise self.messages[len(self.messages) - 1]
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         else:
@@ -1278,7 +1285,7 @@ class Cursor(object):
                     if ibm_db.stmt_errormsg() is not None:
                         self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                         raise self.messages[len(self.messages) - 1]
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
         return return_value
@@ -1290,14 +1297,14 @@ class Cursor(object):
         if not self._result_set_produced:
             try:
                 counter = ibm_db.num_rows(self.stmt_handler)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
             self.__rowcount = counter
         elif self._is_scrollable_cursor:
             try:
                 counter = ibm_db.get_num_result(self.stmt_handler)
-            except Exception, inst:
+            except Exception as inst:
                 self.messages.append(_get_exception(inst))
                 raise self.messages[len(self.messages) - 1]
             if counter >= 0:
@@ -1330,7 +1337,7 @@ class Cursor(object):
                 if ibm_db.stmt_errormsg() is not None:
                     self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                     raise self.messages[len(self.messages) - 1]
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
         return identity_val
@@ -1409,7 +1416,7 @@ class Cursor(object):
                 if ibm_db.stmt_errormsg() is not None:
                     self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                     raise self.messages[len(self.messages) - 1]
-        except Exception, inst:
+        except Exception as inst:
             self._set_rowcount()
             self.messages.append(Error(inst))
             raise self.messages[len(self.messages) - 1]
@@ -1434,7 +1441,7 @@ class Cursor(object):
               (fetch_size != -1 and rows_fetched < fetch_size):
             try:
                 row = ibm_db.fetch_tuple(self.stmt_handler)
-            except Exception, inst:
+            except Exception as inst:
                 if ibm_db.stmt_errormsg() is not None:
                     self.messages.append(Error(str(ibm_db.stmt_errormsg())))
                 else:
@@ -1506,7 +1513,7 @@ class Cursor(object):
             self.__description = None
             self._all_stmt_handlers.append(self.stmt_handler)
             self.stmt_handler = ibm_db.next_result(self._all_stmt_handlers[0])
-        except Exception, inst:
+        except Exception as inst:
             self.messages.append(_get_exception(inst))
             raise self.messages[len(self.messages) - 1]
 
@@ -1545,7 +1552,7 @@ class Cursor(object):
                             row_list = list(row)
                         row_list[index] = decimal.Decimal(str(row[index]).replace(",", "."))
 
-                except Exception, inst:
+                except Exception as inst:
                     self.messages.append(DataError("Data type format error: "+ str(inst)))
                     raise self.messages[len(self.messages) - 1]
         if row_list is None:

--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -277,10 +277,10 @@ setup( name    = PACKAGE,
                       'Programming Language :: Python :: 2',
                       'Programming Language :: Python :: 2.7',
                       'Programming Language :: Python :: 3',
-                      'Programming Language :: Python :: 3.4',
                       'Programming Language :: Python :: 3.5',
                       'Programming Language :: Python :: 3.6',
                       'Programming Language :: Python :: 3.7',
+                      'Programming Language :: Python :: 3.8',
                       'Topic :: Database :: Front-Ends'],
 
        long_description = '''

--- a/IBM_DB/ibm_db/tests/test_251_FreeResult_02.py
+++ b/IBM_DB/ibm_db/tests/test_251_FreeResult_02.py
@@ -26,7 +26,7 @@ class IbmDbTestCase(unittest.TestCase):
         r2 = ibm_db.free_result(result)
         r3 = ''
         try:
-            r3 = ibm_db.free_result(result99)
+            r3 = ibm_db.free_result(result99)  # noqa: F821
         except:
             r3 = None
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Provides Python interface for connecting to IBM DB2 and Informix
    Checkout the [README](https://github.com/ibmdb/python-ibmdb/tree/master/IBM_DB/ibm_db) for getting started with ibm_db and ibm_db_dbi
 
 ## <a name="prereq"></a> Pre-requisites
-Install Python 2.7 or newer versions except python 3.3. Python ibm_db driver does not include support python 3.3 as it has reached end-of-life.
-You might need zlib, openssl, pip installations if not already available in your setup. 
+Install Python 2.7 or Python 3 >= 3.5. Python ibm_db driver does not support Python < 3.5 as they have reached end-of-life.
+You might need zlib, openssl, pip installations if not already available in your setup.
 
 * Linux/Unix:
   If you face problems due to missing python header files while installing the driver, you would need to install python developer package and retry install. e.g:
@@ -61,7 +61,7 @@ You can install the driver using pip as:
 ```
 pip install ibm_db
 ```
-This will install ibm_db and ibm_db_dbi module. 
+This will install ibm_db and ibm_db_dbi module.
 
 * <a name="docker"></a>For installing ibm_db on docker Linux container, you can refer as below:
 ```
@@ -72,10 +72,10 @@ if pip or pip3 does not exist, install it as:
 wget https://bootstrap.pypa.io/get-pip.py
 docker cp get-pip.py /root:<containerid>
 cd root
-python get-pip.py
+python2 get-pip.py or python3 get-pip.py
 
 Install python ibm_db as:
-pip install ibm_db 
+pip install ibm_db
 or
 pip3 install ibm_db
 
@@ -91,36 +91,36 @@ The ODBC and CLI Driver(clidriver) is automatically downloaded at the time of in
 * <a name="envvar"></a>Environment Variables:
   `IBM_DB_HOME :`
 
-  Set this environment variable to avoid automatic downloading of the clidriver during installation. You could set this to the installation path of ODBC and CLI driver in your environment. 
+  Set this environment variable to avoid automatic downloading of the clidriver during installation. You could set this to the installation path of ODBC and CLI driver in your environment.
   e.g:
   ```
   Windows :
   set IBM_DB_HOME=c:/Users/skauser/clidriver
-  
+
   Other platforms:
   export IBM_DB_HOME=/home/skauser/clidriver
   ```
-  
+
   You are required to set the library path to the clidriver under IBM_DB_HOME to pick this version of the ODBC and CLI Driver.
   e.g:
   ```
   Windows:
   set LIB = %IBM_DB_HOME%/lib;%LIB%
- 
+
   AIX:
   export LIBPATH = $IBM_DB_HOME/lib:$LIBPATH
- 
+
   MAC:
   export DYLD_LIBRARY_PATH = $IBM_DB_HOME/lib:$DYLD_LIBRARY_PATH
- 
+
   Other platforms:
   export LD_LIBRARY_PATH = $IBM_DB_HOME/lib:$LD_LIBRARY_PATH
   ```
- 
+
   The ODBC and CLI driver is available for download at [Db2 LUW ODBC and CLI Driver](https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/).
 Refer to ([License requirements](#Licenserequirements)) for more details on the CLI driver for manual download and installation.
- 
- 
+
+
 ## <a name="eg"></a> Quick Example
 ```python
 $ python
@@ -238,7 +238,7 @@ You can refer to [ODBC and CLI Driver installation](http://www-01.ibm.com/suppor
 
 Use following pypi web location for downloading source code and binaries
 **ibm_db**: https://pypi.python.org/pypi/ibm_db .
-You can also get the source code by cloning the ibm_db github repository as : 
+You can also get the source code by cloning the ibm_db github repository as :
 ```
 git clone git@github.com:ibmdb/python-ibmdb.git
 ```


### PR DESCRIPTION
* ibm_db_dbi.py: Old style exceptions --> new style for Python 3 (replaces #396)
* README.md, setup.py, and Travis CI: Add Python 3.8 and drop 3.4 (replaces #446)

DCO 1.1 Signed-off-by: Christian Clauss <cclauss@me.com>