### PR TITLE
Travis CI: Add tests on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,11 @@
 language: python
 
-matrix:
-    include:
-        - python: 2.7
-          dist: trusty
-          sudo: false
-        - python: 3.4
-          dist: trusty
-          sudo: false
-        - python: 3.5
-          dist: trusty
-          sudo: false
-        - python: 3.6
-          dist: trusty
-          sudo: false
-        - python: 3.7
-          dist: xenial
-          sudo: true
+python:
+- 2.7
+- 3.5
+- 3.6
+- 3.7
+- 3.8
 
 install:
 - docker pull ibmcom/db2express-c


### PR DESCRIPTION
Stop testing on dist: Trusty because it is end of life.