### PR TITLE
ci: Fix Docker setup for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: bionic
 language: python
 python:
   - 2.7
@@ -5,17 +7,15 @@ python:
   - 3.6
   - 3.7
   - 3.8
+services:
+  - docker
 
 before_install:
 - pip install --upgrade pip
 - pip install flake8  # find Python syntax errors and undefined names
 - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 install:
-- docker pull ibmcom/db2express-c
-- docker run --name db2  -p 50000:50000 -e DB2INST1_PASSWORD=password -e LICENSE=accept -d ibmcom/db2express-c db2start
-- docker ps -as
-- docker exec -it db2 useradd -ms /bin/bash auth_user -p auth_pass
-- docker exec -it db2 su - db2inst1 -c "db2 create db sample"
+- scripts/setup-docker.sh
 
 script:
 - cd IBM_DB/ibm_db

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x -e -u -o pipefail
+
+docker pull ibmcom/db2
+docker run --name db2 -itd --privileged=true -p 50000:50000 -e LICENSE=accept -e DB2INST1_PASSWORD=password -e DBNAME=sample -v $HOME/database:/database ibmcom/db2
+docker ps -as
+docker exec -it db2 useradd -ms /bin/bash auth_user -p auth_pass
+
+while true
+do
+  if (docker logs db2 | grep 'Setup has completed')
+  then
+      break
+  fi
+
+  sleep 20
+done
+


### PR DESCRIPTION
Switch from ibmcom/db2express-c to ibmcom/db2 docker images and adjust
the setup commands according to the Quick Start guide at
https://hub.docker.com/r/ibmcom/db2.

Because we now need to wait for Db2 to be initialized, the setup
commands were moved from .travis.yml to scripts/setup-docker.sh.

Fixes: #449
Fixes: #485
Co-Authored-By: Christian Clauss <cclauss@me.com>