### PR TITLE
Update image files in ibm_db_tests/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,6 @@ script:
 # set up tests
 - cp config.py.sample config.py
 #
-# These were deleted from git, but required by the tests
-# we just create dummy files of the size expected
-- truncate -s 10291 ibm_db_tests/spook.png
-- truncate -s 15398 ibm_db_tests/pic1.jpg
-#
 # Create db2cli.ini
 - echo -e '[sample]\nHostname=localhost\nProtocol=TCPIP\nDatabase=sample' > db2cli.ini
 - export DB2CLIINIPATH=$PWD

--- a/IBM_DB/ibm_db/ibm_db_tests/test_000_PrepareDb.py
+++ b/IBM_DB/ibm_db/ibm_db_tests/test_000_PrepareDb.py
@@ -89,13 +89,13 @@ class IbmDbTestCase(unittest.TestCase):
             name = animal[0]
 
             with open(os.path.dirname(os.path.abspath(__file__)) + '/' + animal[1], 'rb') as fileHandle:
-               picture = fileHandle.read()
-               if (not picture):
-                   print ("Could not retrieve picture '%s'" % animal[1])
-                   return 0
-               ibm_db.bind_param(stmt, 1, name, ibm_db.SQL_PARAM_INPUT)
-               ibm_db.bind_param(stmt, 2, picture, ibm_db.SQL_PARAM_INPUT)
-               result = ibm_db.execute(stmt)
+                picture = fileHandle.read()
+                if (not picture):
+                    print ("Could not retrieve picture '%s'" % animal[1])
+                    return 0
+                ibm_db.bind_param(stmt, 1, name, ibm_db.SQL_PARAM_INPUT)
+                ibm_db.bind_param(stmt, 2, picture, ibm_db.SQL_PARAM_INPUT)
+                result = ibm_db.execute(stmt)
 
         # Drop the department table, in case it exists
         drop = 'DROP TABLE department'
@@ -297,11 +297,11 @@ class IbmDbTestCase(unittest.TestCase):
                 empno = photo[0]
                 photo_format = photo[1]
                 with open(os.path.dirname(os.path.abspath(__file__)) + '/' + photo[2], 'rb') as fileHandler:
-                   picture = fileHandler.read()
-                   ibm_db.bind_param(stmt, 1, empno, ibm_db.SQL_PARAM_INPUT)
-                   ibm_db.bind_param(stmt, 2, photo_format, ibm_db.SQL_PARAM_INPUT)
-                   ibm_db.bind_param(stmt, 3, picture, ibm_db.SQL_PARAM_INPUT)
-                   result = ibm_db.execute(stmt)
+                    picture = fileHandler.read()
+                    ibm_db.bind_param(stmt, 1, empno, ibm_db.SQL_PARAM_INPUT)
+                    ibm_db.bind_param(stmt, 2, photo_format, ibm_db.SQL_PARAM_INPUT)
+                    ibm_db.bind_param(stmt, 3, picture, ibm_db.SQL_PARAM_INPUT)
+                    result = ibm_db.execute(stmt)
 
         # Drop the org table, in case it exists
         drop = 'DROP TABLE org'

--- a/IBM_DB/ibm_db/ibm_db_tests/test_000_PrepareDb.py
+++ b/IBM_DB/ibm_db/ibm_db_tests/test_000_PrepareDb.py
@@ -87,14 +87,15 @@ class IbmDbTestCase(unittest.TestCase):
             return 0
         for animal in animals:
             name = animal[0]
-            fileHandle = open(os.path.dirname(os.path.abspath(__file__)) + '/' + animal[1], 'rb')
-            picture = fileHandle.read()
-            if (not picture):
-                print ("Could not retrieve picture '%s'" % animal[1])
-                return 0
-            ibm_db.bind_param(stmt, 1, name, ibm_db.SQL_PARAM_INPUT)
-            ibm_db.bind_param(stmt, 2, picture, ibm_db.SQL_PARAM_INPUT)
-            result = ibm_db.execute(stmt)
+
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + animal[1], 'rb') as fileHandle:
+               picture = fileHandle.read()
+               if (not picture):
+                   print ("Could not retrieve picture '%s'" % animal[1])
+                   return 0
+               ibm_db.bind_param(stmt, 1, name, ibm_db.SQL_PARAM_INPUT)
+               ibm_db.bind_param(stmt, 2, picture, ibm_db.SQL_PARAM_INPUT)
+               result = ibm_db.execute(stmt)
 
         # Drop the department table, in case it exists
         drop = 'DROP TABLE department'
@@ -295,12 +296,12 @@ class IbmDbTestCase(unittest.TestCase):
             for photo in emp_photo:
                 empno = photo[0]
                 photo_format = photo[1]
-                fileHandler = open(os.path.dirname(os.path.abspath(__file__)) + '/' + photo[2], 'rb')
-                picture = fileHandler.read()
-                ibm_db.bind_param(stmt, 1, empno, ibm_db.SQL_PARAM_INPUT)
-                ibm_db.bind_param(stmt, 2, photo_format, ibm_db.SQL_PARAM_INPUT)
-                ibm_db.bind_param(stmt, 3, picture, ibm_db.SQL_PARAM_INPUT)
-                result = ibm_db.execute(stmt)
+                with open(os.path.dirname(os.path.abspath(__file__)) + '/' + photo[2], 'rb') as fileHandler:
+                   picture = fileHandler.read()
+                   ibm_db.bind_param(stmt, 1, empno, ibm_db.SQL_PARAM_INPUT)
+                   ibm_db.bind_param(stmt, 2, photo_format, ibm_db.SQL_PARAM_INPUT)
+                   ibm_db.bind_param(stmt, 3, picture, ibm_db.SQL_PARAM_INPUT)
+                   result = ibm_db.execute(stmt)
 
         # Drop the org table, in case it exists
         drop = 'DROP TABLE org'

--- a/IBM_DB/ibm_db/ibm_db_tests/test_045_FetchTupleBinaryData_01.py
+++ b/IBM_DB/ibm_db/ibm_db_tests/test_045_FetchTupleBinaryData_01.py
@@ -28,7 +28,7 @@ class IbmDbTestCase(unittest.TestCase):
             print(ibm_db.stmt_errormsg())
         fp.close()
         with open('ibm_db_tests/pic1_out.jpg', 'rb') as fp1, open('ibm_db_tests/pic1.jpg', 'rb') as fp2:
-           cmp = (fp1.read() == fp2.read())
+            cmp = (fp1.read() == fp2.read())
         print('Are the files the same:', cmp)
 
 

--- a/IBM_DB/ibm_db/ibm_db_tests/test_045_FetchTupleBinaryData_01.py
+++ b/IBM_DB/ibm_db/ibm_db_tests/test_045_FetchTupleBinaryData_01.py
@@ -27,7 +27,8 @@ class IbmDbTestCase(unittest.TestCase):
         else:
             print(ibm_db.stmt_errormsg())
         fp.close()
-        cmp = (open('ibm_db_tests/pic1_out.jpg', 'rb').read() == open('ibm_db_tests/pic1.jpg', 'rb').read())
+        with open('ibm_db_tests/pic1_out.jpg', 'rb') as fp1, open('ibm_db_tests/pic1.jpg', 'rb') as fp2:
+           cmp = (fp1.read() == fp2.read())
         print('Are the files the same:', cmp)
 
 

--- a/IBM_DB/ibm_db/ibm_db_tests/test_048_FetchTupleBinaryData_02.py
+++ b/IBM_DB/ibm_db/ibm_db_tests/test_048_FetchTupleBinaryData_02.py
@@ -39,7 +39,7 @@ class IbmDbTestCase(unittest.TestCase):
             print(ibm_db.stmt_errormsg())
         fp.close()
         with open('ibm_db_tests/spook_out.png', "rb") as fp1, open('ibm_db_tests/spook.png', "rb") as fp2:
-           cmp = (fp1.read() == fp2.read())
+            cmp = (fp1.read() == fp2.read())
         print("Are the files the same:", cmp)
 
 #__END__

--- a/IBM_DB/ibm_db/ibm_db_tests/test_048_FetchTupleBinaryData_02.py
+++ b/IBM_DB/ibm_db/ibm_db_tests/test_048_FetchTupleBinaryData_02.py
@@ -38,7 +38,8 @@ class IbmDbTestCase(unittest.TestCase):
         else:
             print(ibm_db.stmt_errormsg())
         fp.close()
-        cmp = (open('ibm_db_tests/spook_out.png', "rb").read() == open('ibm_db_tests/spook.png', "rb").read())
+        with open('ibm_db_tests/spook_out.png', "rb") as fp1, open('ibm_db_tests/spook.png', "rb") as fp2:
+           cmp = (fp1.read() == fp2.read())
         print("Are the files the same:", cmp)
 
 #__END__

--- a/IBM_DB/ibm_db/tests.py
+++ b/IBM_DB/ibm_db/tests.py
@@ -24,6 +24,13 @@ import importlib
 def load_tests(loader, tests, pattern):
     suite = unittest.TestSuite()
 
+    # We need files of a given size for some of the test units, so create them
+    # here.
+    with open("ibm_db_tests/spook.png", "wb") as f:
+        f.truncate(10291)
+    with open("ibm_db_tests/pic1.jpg", "wb") as f:
+        f.truncate(15398)
+
     test_glob = os.environ.get("SINGLE_PYTHON_TEST", "test_*.py")
     files = glob.glob(join(config.test_dir, test_glob))
     tests = [ basename(_).replace('.py', '') for _ in files ]

--- a/IBM_DB/ibm_db/tests.py
+++ b/IBM_DB/ibm_db/tests.py
@@ -1,5 +1,6 @@
 import os
 from os.path import basename, join
+import random
 import sys
 import unittest
 import glob
@@ -27,9 +28,9 @@ def load_tests(loader, tests, pattern):
     # We need files of a given size for some of the test units, so create them
     # here.
     with open("ibm_db_tests/spook.png", "wb") as f:
-        f.truncate(10291)
+        f.write(bytes([random.getrandbits(8) for _ in range(0, 10291)]))
     with open("ibm_db_tests/pic1.jpg", "wb") as f:
-        f.truncate(15398)
+        f.write(bytes([random.getrandbits(8) for _ in range(0, 15398)]))
 
     test_glob = os.environ.get("SINGLE_PYTHON_TEST", "test_*.py")
     files = glob.glob(join(config.test_dir, test_glob))

--- a/IBM_DB/ibm_db/tests.py
+++ b/IBM_DB/ibm_db/tests.py
@@ -28,9 +28,9 @@ def load_tests(loader, tests, pattern):
     # We need files of a given size for some of the test units, so create them
     # here.
     with open("ibm_db_tests/spook.png", "wb") as f:
-        f.write(bytes([random.getrandbits(8) for _ in range(0, 10291)]))
+        f.write(bytearray([random.getrandbits(8) for _ in range(0, 10291)]))
     with open("ibm_db_tests/pic1.jpg", "wb") as f:
-        f.write(bytes([random.getrandbits(8) for _ in range(0, 15398)]))
+        f.write(bytearray([random.getrandbits(8) for _ in range(0, 15398)]))
 
     test_glob = os.environ.get("SINGLE_PYTHON_TEST", "test_*.py")
     files = glob.glob(join(config.test_dir, test_glob))


### PR DESCRIPTION
This fixes an issue where the image files needed by unit tests 000, 045, and 048 were missing and would lead to test failures when run locally.

* Added IBM_DB/ibm_db/ibm_db_tests/pic1.jpg and IBM_DB/ibm_db/ibm_db_tests/spook.png (the same files that were removed in c6fe669).
* Updated .travis.yaml to no longer create dummy files.
* Updated test units 000, 045, 048 to remove "ResourceWarning: unclosed file" warnings.

Fixes #512.

DCO 1.1 Signed-off-by: David Mooney <pez@vex.net>