### PR TITLE
MacOS: Installer fails on Python 2.7

### DIFF
--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -65,7 +65,7 @@ if('darwin' in sys.platform):
     class PostBuildExt(build_ext):
         """ Post build_ext - update db2 dynamic lib to use loader_path on Darwin """
         def run(self):
-            super().run()
+            build_ext.run(self)
             clipath = os.getenv('IBM_DB_HOME', '@loader_path/clidriver')
             for so in glob.glob(self.build_lib+r'/ibm_db*.so'):
                 os.system("install_name_tool -change libdb2.dylib {}/lib/libdb2.dylib {}".format(clipath, so))


### PR DESCRIPTION
Remove use of `super().run()` and call `build_ext.run(self)` instead to remain compatible with Python 2.7.
Fixes #521 
DCO 1.1 Signed-off-by: David Mooney pez@vex.net