### PR TITLE
Pull macOs ODBC from alternative location

### DIFF
--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -186,7 +186,7 @@ if (('IBM_DB_HOME' not in os.environ) and ('IBM_DB_DIR' not in os.environ) and (
 
     elif('darwin' in sys.platform and is64Bit):
         os_ = 'mac'
-        cliFileName = 'macos64_odbc_cli.tar.gz'
+        cliFileName = 'linuxx64/macos64_odbc_cli.tar.gz'
         arch_ = 'x86_64'
     else:
         sys.stdout.write("Not a known platform for python ibm_db.\n")


### PR DESCRIPTION
Supports https://github.com/ibmdb/python-ibmdb/issues/540#issuecomment-675803419

https://github.com/ibmdb/python-ibmdb/issues/540 is failing many macOs user from properly install ibmdb. While we are waiting for a better fix, this alternative driver location has proven to be working.