### PR TITLE
Add custom clidriver\bin path for ibm_db.py

### DIFF
--- a/IBM_DB/ibm_db/setup.py
+++ b/IBM_DB/ibm_db/setup.py
@@ -127,8 +127,9 @@ def _setWinEnv(name, value):
     if name not in old:
         pyFile.seek(0)
         envVal = "import os\n" + \
-                '''if 'clidriver' not in os.environ['%(name)s']:\n    os.environ['%(name)s'] = os.environ['%(name)s']''' % {'name': name}
-        envVal = envVal + ''' + ";" + os.path.join(os.path.abspath(os.path.dirname(__file__)), '%(val)s', 'bin')''' % {'val': value}
+                '''if 'IBM_DB_HOME' in os.environ:\n    ibm_db_home = os.getenv('IBM_DB_HOME')\n''' + \
+                '''else:\n    ibm_db_home = os.path.join(os.path.abspath(os.path.dirname(__file__)), '%(val)s')\n'''  % {'val': value}
+        envVal = envVal + '''os.environ['%(name)s'] = os.environ['%(name)s'] + ";" + os.path.join(ibm_db_home, 'bin')''' % {'name': name}
         pyFile.write( envVal + "\n" + old )
     pyFile.close()
 


### PR DESCRIPTION
The ibm_db.py file now adds a custom `clidriver\bin` path, which can be either `C:\Users\XXX\AppData\Local\Programs\Python\Python37\Lib\site-packages\clidriver\bin` or `C:\Users\XXX\Documents\clidriver\bin` or ... according to where the clidriver is installed.

I removed the initial
```
if 'clidriver' not in os.environ['%(name)s']
```
As it can leads to error when one added `<clidriver_folder_path>\bin\amd64.VC12.CRT` to PATH but not `<clidriver_folder_path>\bin`.


Signed-off-by: Alexandre Duverger <alexandre.duverger@solution-bi.com>