### PR TITLE
fixed Typo on clidriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you have to use your own URL for clidriver.tar.gz/.zip please set environment
 IBM_DB_INSTALLER_URL=full_path_of_clidriver.tar.gz/.zip
 ```
 When ibm_db get installed from wheel package, you can find clidriver under site_packages directory
-of Python. You need to copy license file under `site_packages/clidirver/license` to be effective, if any.
+of Python. You need to copy license file under `site_packages/clidriver/license` to be effective, if any.
 
 **Note:** For windows after installing ibm_db, recieves the below error when we try to import ibm_db :
 ```>python


### PR DESCRIPTION
Fixed a text  "You need to copy license file under `site_packages/clidirver/license` to be effective" spelling of clidriver

![image](https://github.com/ibmdb/python-ibmdb/assets/22093620/a8ec3e41-462f-483d-b9a9-1e6fdba52d7b)

This is first time I am dealing with github . Hopefully have done it correctly :)