### PR TITLE
Support for python3.12

### DIFF
--- a/.github/workflows/bld_wheels_and_upload.yml
+++ b/.github/workflows/bld_wheels_and_upload.yml
@@ -6,10 +6,10 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - ibmdb_python312
   # Sequence of patterns matched against refs/tags
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    #tags:
+      #- 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build_wheels_windows_64:
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
      #upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push'
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -123,9 +123,10 @@ jobs:
         name: artifact
         path: dist
     - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      #if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        repository-url: https://test.pypi.org/legacy/
         user: ${{secrets.PYPI_USER}}
         password: ${{ secrets.PYPI_PASSWORD}}
 

--- a/.github/workflows/bld_wheels_and_upload.yml
+++ b/.github/workflows/bld_wheels_and_upload.yml
@@ -19,13 +19,13 @@ jobs:
       matrix:
         os: [windows-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: "*-win_amd64"
           CIBW_SKIP: "cp36-* pp*"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.1
         with:
           path: ./wheelhouse/*.whl   
   
@@ -36,13 +36,13 @@ jobs:
       matrix:
         os: [windows-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: "*-win32"
           CIBW_SKIP: "cp36-* pp*"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.3.1
         with:
           path: ./wheelhouse/*.whl       
   build_wheels_macos_linux:

--- a/.github/workflows/bld_wheels_and_upload.yml
+++ b/.github/workflows/bld_wheels_and_upload.yml
@@ -6,10 +6,10 @@ on:
   pull_request:
   push:
     branches:
-      - ibmdb_python312
+      - master
   # Sequence of patterns matched against refs/tags
-    #tags:
-      #- 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build_wheels_windows_64:
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
      #upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -123,10 +123,9 @@ jobs:
         name: artifact
         path: dist
     - name: Publish distribution to PyPI
-      #if: startsWith(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
         user: ${{secrets.PYPI_USER}}
         password: ${{ secrets.PYPI_PASSWORD}}
 

--- a/.github/workflows/bld_wheels_and_upload.yml
+++ b/.github/workflows/bld_wheels_and_upload.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           CIBW_BUILD: "*-win32"
           CIBW_SKIP: "cp36-* pp*"
-      - uses: actions/upload-artifact@v4.3.1
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl       
   build_wheels_macos_linux:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/ibmdb/python-ibmdb/wiki/APIs
 
 <a name="prereq"></a>
 ## Pre-requisites
-Install Python 3.7 <= 3.11. The minimum python version supported by driver is python 3.7 and the latest version supported is python 3.11.
+Install Python 3.7 <= 3.12. The minimum python version supported by driver is python 3.7 and the latest version supported is python 3.12.
 
 ### To install ibm_db on z/OS system
 

--- a/ibm_db.c
+++ b/ibm_db.c
@@ -1579,7 +1579,7 @@ static PyObject* getSQLWCharAsPyUnicodeObject(SQLWCHAR* sqlwcharData, int sqlwch
 
     if (maxuniValue <= 65536) {
     /* this is UCS2 python.. nothing to do really */
-        return PyUnicode_FromUnicode((Py_UNICODE *)sqlwcharData, sqlwcharBytesLen / sizeof(SQLWCHAR));
+        return PyUnicode_FromWideChar((Py_UNICODE *)sqlwcharData, sqlwcharBytesLen / sizeof(SQLWCHAR));
         }
 
     if (is_bigendian()) {
@@ -1619,7 +1619,7 @@ static SQLWCHAR* getUnicodeDataAsSQLWCHAR(PyObject *pyobj, int *isNewBuffer)
     long maxuniValue;
     PyObject *pyUTFobj;
     SQLWCHAR* pNewBuffer = NULL;
-    int nCharLen = PyUnicode_GET_SIZE(pyobj);
+    int nCharLen = PyUnicode_GET_LENGTH(pyobj);
 
     sysmodule = PyImport_ImportModule("sys");
     maxuni = PyObject_GetAttrString(sysmodule, "maxunicode");
@@ -1627,7 +1627,7 @@ static SQLWCHAR* getUnicodeDataAsSQLWCHAR(PyObject *pyobj, int *isNewBuffer)
 
     if (maxuniValue <= 65536) {
         *isNewBuffer = 0;
-        return (SQLWCHAR*)PyUnicode_AS_UNICODE(pyobj);
+        return (SQLWCHAR*)PyUnicode_AsWideCharString(pyobj,maxuniValue);
     }
 
     *isNewBuffer = 1;

--- a/ibm_db.c
+++ b/ibm_db.c
@@ -1438,19 +1438,19 @@ static PyObject *_python_ibm_db_connect_helper( PyObject *self, PyObject *args, 
 #ifdef __MVS__
                 rc = SQLConnectW((SQLHDBC)conn_res->hdbc,
                     database,
-                    PyUnicode_GetSize(databaseObj)*2,
+                    PyUnicode_GetLength(databaseObj)*2,
                     uid,
-                    PyUnicode_GetSize(uidObj)*2,
+                    PyUnicode_GetLength(uidObj)*2,
                     password,
-                    PyUnicode_GetSize(passwordObj)*2);
+                    PyUnicode_GetLength(passwordObj)*2);
 #else
                 rc = SQLConnectW((SQLHDBC)conn_res->hdbc,
                     database,
-                    PyUnicode_GetSize(databaseObj),
+                    PyUnicode_GetLength(databaseObj),
                     uid,
-                    PyUnicode_GetSize(uidObj),
+                    PyUnicode_GetLength(uidObj),
                     password,
-                    PyUnicode_GetSize(passwordObj));
+                    PyUnicode_GetLength(passwordObj));
 #endif
                 Py_END_ALLOW_THREADS;
             }
@@ -5373,7 +5373,7 @@ static PyObject *_python_ibm_db_prepare_helper(conn_handle *conn_res, PyObject *
         if (PyString_Check(py_stmt) || PyUnicode_Check(py_stmt)) {
             py_stmt = PyUnicode_FromObject(py_stmt);
             if (py_stmt != NULL &&  py_stmt != Py_None) {
-                stmt_size = PyUnicode_GetSize(py_stmt);
+                stmt_size = PyUnicode_GetLength(py_stmt);
             } else {
                 PyErr_SetString(PyExc_Exception, "Error occure during processing of statement");
                 return NULL;
@@ -5893,7 +5893,7 @@ static int _python_ibm_db_bind_data( stmt_handle *stmt_res, param_node *curr, Py
                                     tmp_uvalue = NULL;
                                 }
                                 tmp_uvalue = getUnicodeDataAsSQLWCHAR(item, &isNewBuffer);
-                                curr->ivalue = PyUnicode_GetSize(item);
+                                curr->ivalue = PyUnicode_GetLength(item);
                                 curr->ivalue = curr->ivalue * sizeof(SQLWCHAR);
                             }
                             param_length = curr->ivalue;
@@ -6060,7 +6060,7 @@ static int _python_ibm_db_bind_data( stmt_handle *stmt_res, param_node *curr, Py
                             curr->uvalue = NULL;
                         }
                         curr->uvalue = getUnicodeDataAsSQLWCHAR(bind_data, &isNewBuffer);
-                        curr->ivalue = PyUnicode_GetSize(bind_data);
+                        curr->ivalue = PyUnicode_GetLength(bind_data);
                         curr->ivalue = curr->ivalue * sizeof(SQLWCHAR);
                     }
                     param_length = curr->ivalue;

--- a/ibm_db.c
+++ b/ibm_db.c
@@ -22,7 +22,7 @@
 +--------------------------------------------------------------------------+
 */
 
-#define MODULE_RELEASE "3.1.6"
+#define MODULE_RELEASE "3.2.1"
 
 #include <Python.h>
 #include <datetime.h>

--- a/ibm_db.c
+++ b/ibm_db.c
@@ -22,7 +22,7 @@
 +--------------------------------------------------------------------------+
 */
 
-#define MODULE_RELEASE "3.2.1"
+#define MODULE_RELEASE "3.1.6"
 
 #include <Python.h>
 #include <datetime.h>

--- a/ibm_db.h
+++ b/ibm_db.h
@@ -47,7 +47,7 @@
 #define StringOBJ_FromStr(str)      PyUnicode_DecodeLocale(str, NULL)
 #define PyString_Check              PyUnicode_Check
 #define StringObj_Format            PyUnicode_Format
-#define StringObj_Size              PyUnicode_GET_SIZE
+#define StringObj_Size              PyUnicode_GET_LENGTH
 #define MOD_RETURN_ERROR            NULL
 #define MOD_RETURN_VAL(mod)         mod
 #define INIT_ibm_db PyInit_ibm_db

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,14 @@ else:
     import urllib2 as request
     from cStringIO import StringIO as BytesIO
 
-from distutils import ccompiler
-from distutils import sysconfig as distutils_sysconfig
-from distutils.sysconfig import get_python_lib
+if sys.version_info.major == 3 and sys.version_info.minor >= 12:
+    from setuptools._distutils import ccompiler
+    from setuptools._distutils import sysconfig as distutils_sysconfig
+    from setuptools._distutils.sysconfig import get_python_lib
+else:
+    from distutils import ccompiler
+    from distutils import sysconfig as distutils_sysconfig
+    from distutils.sysconfig import get_python_lib
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
@@ -62,7 +67,7 @@ def _printAndExit(msg):
       
 def _errormessage(option):
     if(option == "downloadFailedWin"):
-        message = "\nPlease download the clidriver manually from the above link and unzip the contents into a particular location.\nSet the location of the directory to the system enviroment variable \"IBM_DB_HOME\"\nExample set IBM_DB_HOME=C:\downloads\db2driver\clidriver\nOnce the above settings are done please try installing ibm_db again."
+        message = "\nPlease download the clidriver manually from the above link and unzip the contents into a particular location.\nSet the location of the directory to the system enviroment variable \"IBM_DB_HOME\"\nExample set IBM_DB_HOME=C:/downloads/db2driver/clidriver\nOnce the above settings are done please try installing ibm_db again."
     if(option == "downloadFailed"):
         message = "\nPlease download the clidriver manually from the above link and untar the contents into a particular directory.\nSet the location of the directory to the system enviroment variable \"IBM_DB_HOME\"\nExample export IBM_DB_HOME=/home/db2driver/clidriver\nOnce the above settings are done try installing ibm_db again."
     if(option == "includeFolderMissing"):
@@ -525,6 +530,7 @@ setup( name    = PACKAGE,
                     'Programming Language :: Python :: 3.9',
                     'Programming Language :: Python :: 3.10',
                     'Programming Language :: Python :: 3.11',
+                    'Programming Language :: Python :: 3.12',
                     'Topic :: Database :: Front-Ends'],
 
     long_description = 'Python DBI driver for IBM Db2 for LUW, IBM Informix, IBM Db2 for iSeries(AS400) and IBM Db2 for z/OS servers',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
 
 PACKAGE = 'ibm_db'
-VERSION = '3.1.6'
+VERSION = '3.2.1'
 LICENSE = 'Apache License 2.0'
 readme = os.path.join(os.path.dirname(__file__),'README.md')
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
 
 PACKAGE = 'ibm_db'
-VERSION = '3.2.1'
+VERSION = '3.1.6'
 LICENSE = 'Apache License 2.0'
 readme = os.path.join(os.path.dirname(__file__),'README.md')
 

--- a/testfunctions.py
+++ b/testfunctions.py
@@ -139,10 +139,7 @@ class IbmDbTestFunctions(unittest.TestCase):
             else:
                 pattern = self.expected_LUW(callstack[1][1])
 
-            if sys.version_info.major == 3 and sys.version_info.minor >= 12:
-                sym = ['/[', '/]', '/(', '/)']
-            else:
-                sym = ['\[','\]','\(','\)']
+            sym = ['\[','\]','\(','\)']
             for chr in sym:
                 pattern = re.sub(chr, '\\' + chr, pattern)
 

--- a/testfunctions.py
+++ b/testfunctions.py
@@ -139,7 +139,10 @@ class IbmDbTestFunctions(unittest.TestCase):
             else:
                 pattern = self.expected_LUW(callstack[1][1])
 
-            sym = ['\[','\]','\(','\)']
+            if sys.version_info.major == 3 and sys.version_info.minor >= 12:
+                sym = ['/[', '/]', '/(', '/)']
+            else:
+                sym = ['\[','\]','\(','\)']
             for chr in sym:
                 pattern = re.sub(chr, '\\' + chr, pattern)
 


### PR DESCRIPTION
As many users requested support for Python 3.12 in Python-ibmdb,
To give this support created Epic for Python 3.12 support: https://jira.rocketsoftware.com/browse/DBC-14681

With these changes, users will be able to work on Python-ibmdb using Python 3.12.x.