### PR TITLE
Downgrade upload-artifact on 64 bit Windows

### DIFF
--- a/.github/workflows/bld_wheels_and_upload.yml
+++ b/.github/workflows/bld_wheels_and_upload.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           CIBW_BUILD: "*-win_amd64"
           CIBW_SKIP: "cp36-* pp*"
-      - uses: actions/upload-artifact@v4.3.1
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl   
   


### PR DESCRIPTION
actions/upload-artifact was only bumped to v4 on 64 bit Windows. Artifacts created with v4 can not be downloaded by v3, so the download step in the release job completely misses the 64 bit Windows wheels.

ref: https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/

Fixes part of #918