### PR TITLE
Upgrade cibuildwheel on Linux & Mac OS job

### DIFF
--- a/.github/workflows/bld_wheels_and_upload.yml
+++ b/.github/workflows/bld_wheels_and_upload.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
          CIBW_SKIP: "cp36-* *-musllinux_* pp* *-*linux_{aarch64,ppc64le}"


### PR DESCRIPTION
cibuildwheel was already bumped for the Windows 62 and 64 bit jobs, but the Linux and Mac OS jobs were still using the old version, which doesn't support Python 3.12.
So despite the advertised support for Python 3.12, the 3.12 wheels were not actually being uploaded.

Fixes part of #918