### PR TITLE
945 Update trusted-context testscripts for current cldriver messages and also allow running from remote

### DIFF
--- a/config.py.sample
+++ b/config.py.sample
@@ -17,7 +17,7 @@ if sys.platform != 'zos':
 
     env_not_set = False
     if 'DB2_USER' in os.environ:
-        user = os.getenv('DB2_USER')          # User ID to connect with
+        user = os.getenv('DB2_USER')          # User ID to connect with (must be secadm for trusted-context testcases)
     else:
         user = data['user']
         env_not_set = True
@@ -52,3 +52,5 @@ auth_user   =    'auth_user'    # Authentic user of Database
 auth_pass   =    'auth_pass'    # Password for Authentic user
 tc_user     =    'tc_user'    # Trusted user
 tc_pass     =    'tc_pass'    # Password to trusted user
+tc_appserver_address = '' # optional. Hostname/IP-address, where trusted-context testcases run, defaults to local hostname
+

--- a/ibm_db_tests/test_trusted_context_connect.py
+++ b/ibm_db_tests/test_trusted_context_connect.py
@@ -23,10 +23,18 @@ class IbmDbTestCase(unittest.TestCase):
         obj.assert_expectf(self.run_test_trusted_context_connect)
 
     def run_test_trusted_context_connect(self):
+        # if the Db2-server cannot resolve the remote-client hostname(where testcase runs), then use config.py tc_appserver_address to give IP-address
+        # and use that IP-address in the trusted-context definition, to allow operation remotely from the Db2-server.
+
         if ( sys.platform == 'win32'):  # on ms-windows get hostname from env to avoid importing other modules
             this_hostname = os.environ['COMPUTERNAME']
         else:
             this_hostname = os.uname()[1]  # get local non-windows hostname
+
+        if config.tc_appserver_address:
+            if config.tc_appserver_address != '':
+                this_hostname = config.tc_appserver_address # in case Db2-server cannot resolve remote-client hostname
+ 
         
         sql_drop_role = "DROP ROLE role_01"
         sql_create_role = "CREATE ROLE role_01"

--- a/ibm_db_tests/test_trusted_context_connect.py
+++ b/ibm_db_tests/test_trusted_context_connect.py
@@ -23,6 +23,11 @@ class IbmDbTestCase(unittest.TestCase):
         obj.assert_expectf(self.run_test_trusted_context_connect)
 
     def run_test_trusted_context_connect(self):
+        if ( sys.platform == 'win32'):  # on ms-windows get hostname from env to avoid importing other modules
+            this_hostname = os.environ['COMPUTERNAME']
+        else:
+            this_hostname = os.uname()[1]  # get local non-windows hostname
+        
         sql_drop_role = "DROP ROLE role_01"
         sql_create_role = "CREATE ROLE role_01"
 
@@ -31,7 +36,7 @@ class IbmDbTestCase(unittest.TestCase):
         sql_create_trusted_context = "CREATE TRUSTED CONTEXT ctx BASED UPON CONNECTION USING SYSTEM AUTHID "
         sql_create_trusted_context += config.auth_user
         sql_create_trusted_context += " ATTRIBUTES (ADDRESS '"
-        sql_create_trusted_context += config.hostname
+        sql_create_trusted_context += this_hostname
         sql_create_trusted_context += "') DEFAULT ROLE role_01 ENABLE WITH USE FOR "
         sql_create_trusted_context += config.tc_user
 
@@ -324,7 +329,7 @@ class IbmDbTestCase(unittest.TestCase):
 #But trusted user is not switched.
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Trusted connection succeeded.
 #[%s][%s][%s] SQL30082N  Security processing failed with reason "24" ("USERNAME AND/OR PASSWORD INVALID").  SQLSTATE=08001 SQLCODE=-30082
 #Trusted connection succeeded.
@@ -334,7 +339,7 @@ class IbmDbTestCase(unittest.TestCase):
 #[%s][%s][%s] SQL20361N  The switch user request using authorization ID "%s" within trusted context "CTX" failed with reason code "2".  SQLSTATE=42517 SQLCODE=-20361
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "INSERT" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "INSERT". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Connection succeeded.
 #__ZOS_EXPECTED__
 #Normal connection established.
@@ -344,7 +349,7 @@ class IbmDbTestCase(unittest.TestCase):
 #But trusted user is not switched.
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Trusted connection succeeded.
 #[%s][%s][%s] SQL30082N  Security processing failed with reason "24" ("USERNAME AND/OR PASSWORD INVALID").  SQLSTATE=08001 SQLCODE=-30082
 #Trusted connection succeeded.
@@ -354,7 +359,7 @@ class IbmDbTestCase(unittest.TestCase):
 #[%s][%s][%s] SQL20361N  The switch user request using authorization ID "%s" within trusted context "CTX" failed with reason code "2".  SQLSTATE=42517 SQLCODE=-20361
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "INSERT" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "INSERT". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Connection succeeded.
 #__SYSTEMI_EXPECTED__
 #Normal connection established.
@@ -364,7 +369,7 @@ class IbmDbTestCase(unittest.TestCase):
 #But trusted user is not switched.
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Trusted connection succeeded.
 #[%s][%s][%s] SQL30082N  Security processing failed with reason "24" ("USERNAME AND/OR PASSWORD INVALID").  SQLSTATE=08001 SQLCODE=-30082
 #Trusted connection succeeded.
@@ -374,7 +379,7 @@ class IbmDbTestCase(unittest.TestCase):
 #[%s][%s][%s] SQL20361N  The switch user request using authorization ID "%s" within trusted context "CTX" failed with reason code "2".  SQLSTATE=42517 SQLCODE=-20361
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "INSERT" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "INSERT". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Connection succeeded.
 #__IDS_EXPECTED__
 #Normal connection established.
@@ -384,7 +389,7 @@ class IbmDbTestCase(unittest.TestCase):
 #But trusted user is not switched.
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Trusted connection succeeded.
 #[%s][%s][%s] SQL30082N  Security processing failed with reason "24" ("USERNAME AND/OR PASSWORD INVALID").  SQLSTATE=08001 SQLCODE=-30082
 #Trusted connection succeeded.
@@ -394,5 +399,5 @@ class IbmDbTestCase(unittest.TestCase):
 #[%s][%s][%s] SQL20361N  The switch user request using authorization ID "%s" within trusted context "CTX" failed with reason code "2".  SQLSTATE=42517 SQLCODE=-20361
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "INSERT" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "INSERT". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Connection succeeded.

--- a/ibm_db_tests/test_trusted_context_pconnect.py
+++ b/ibm_db_tests/test_trusted_context_pconnect.py
@@ -23,6 +23,11 @@ class IbmDbTestCase(unittest.TestCase):
         obj.assert_expectf(self.run_test_trusted_context_pconnect)
 
     def run_test_trusted_context_pconnect(self):
+        if ( sys.platform == 'win32'):  # on ms-windows get hostname from env to avoid importing other modules
+            this_hostname = os.environ['COMPUTERNAME']
+        else:
+            this_hostname = os.uname()[1]  # get local non-windows hostname
+    
         sql_drop_role = "DROP ROLE role_01"
         sql_create_role = "CREATE ROLE role_01"
 
@@ -31,7 +36,7 @@ class IbmDbTestCase(unittest.TestCase):
         sql_create_trusted_context = "CREATE TRUSTED CONTEXT ctx BASED UPON CONNECTION USING SYSTEM AUTHID "
         sql_create_trusted_context += config.auth_user
         sql_create_trusted_context += " ATTRIBUTES (ADDRESS '"
-        sql_create_trusted_context += config.hostname
+        sql_create_trusted_context += this_hostname
         sql_create_trusted_context += "') DEFAULT ROLE role_01 ENABLE WITH USE FOR "
         sql_create_trusted_context += config.tc_user
 
@@ -154,7 +159,7 @@ class IbmDbTestCase(unittest.TestCase):
 #__LUW_EXPECTED__
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.
@@ -169,7 +174,7 @@ class IbmDbTestCase(unittest.TestCase):
 #__ZOS_EXPECTED__
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.
@@ -184,7 +189,7 @@ class IbmDbTestCase(unittest.TestCase):
 #__SYSTEMI_EXPECTED__
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.
@@ -199,7 +204,7 @@ class IbmDbTestCase(unittest.TestCase):
 #__IDS_EXPECTED__
 #Trusted connection succeeded.
 #User has been switched.
-#[%s][%s][%s] SQL0551N  "%s" does not have the %s privilege to perform operation "UPDATE" on object "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
+#[%s][%s][%s] SQL0551N  The statement failed because the authorization ID does not have the required authorization or privilege to perform the operation.  Authorization ID: "%s".  Operation: "UPDATE". Object: "%s.TRUSTED_TABLE".  SQLSTATE=42501 SQLCODE=-551
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.
 #Explicit Trusted Connection succeeded.

--- a/ibm_db_tests/test_trusted_context_pconnect.py
+++ b/ibm_db_tests/test_trusted_context_pconnect.py
@@ -27,6 +27,12 @@ class IbmDbTestCase(unittest.TestCase):
             this_hostname = os.environ['COMPUTERNAME']
         else:
             this_hostname = os.uname()[1]  # get local non-windows hostname
+
+        if config.tc_appserver_address:
+            if config.tc_appserver_address != '': 
+                this_hostname = config.tc_appserver_address # in case Db2-server cannot resolve remote-client hostname
+ 
+
     
         sql_drop_role = "DROP ROLE role_01"
         sql_create_role = "CREATE ROLE role_01"


### PR DESCRIPTION
See https://github.com/ibmdb/python-ibmdb/issues/945

This P.R containes three altered files that are solely related to testing scripts for python-ibmdb.

test_trusted_context_connect.py
test_trusted_context_pconnect.py
config.py.sample

The changes allow these scripts to work with the currently shipping clidriver (version 11.5.9.0) which has the english-language message-texts for at least one SQLCODE changed slightly since earlier releases.
The changes also allow both of these testscripts to run on a hostname that is different from that of the Db2-server (i.e. to run from remote) which is made possible either by default using the local hostname in the trusted-context definition, or alternatively by specifying the ip-address of the remote-hostname in the config.py (for which a remark is added to config.py.sample, that is useful when the Db2-server cannot resolve the hostname of the remote-client but CAN access it via tcpip).
No additional python modules (other than those already required by other testcases) are required to run these tests