### PR TITLE
Support Python 3.13 and add fetch APIs (fetchone, fetchmany, fetchall)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/ibmdb/python-ibmdb/wiki/APIs
 
 <a name="prereq"></a>
 ## Pre-requisites
-Install Python 3.7 <= 3.12. The minimum python version supported by driver is python 3.7 and the latest version supported is python 3.12.
+Install Python 3.7 <= 3.13. The minimum python version supported by driver is python 3.7 and the latest version supported is python 3.13.
 
 ### To install ibm_db on z/OS system
 

--- a/ibm_db_dbi.py
+++ b/ibm_db_dbi.py
@@ -23,9 +23,9 @@ This module implements the Python DB API Specification v2.0 for DB2 database.
 
 import types, string, time, datetime, decimal, sys
 import weakref
-import logging
+import logging as log_ibmdb_dbi
 
-logger = logging.getLogger(__name__)
+logger = log_ibmdb_dbi.getLogger(__name__)
 log_enabled = False
 
 # Define macros for log levels
@@ -41,12 +41,12 @@ def debug(option):
     if isinstance(option, bool):
         log_enabled = option
         if log_enabled:
-            logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+            log_ibmdb_dbi.basicConfig(level=log_ibmdb_dbi.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
     elif isinstance(option, str):
         log_enabled = True  # Set log_enabled to True
         if '.' not in option:
             option += '.txt'
-        logging.basicConfig(filename=option, level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s',
+        log_ibmdb_dbi.basicConfig(filename=option, level=log_ibmdb_dbi.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s',
                             filemode='w')
     else:
         print("Invalid argument in debug. Please give a boolean or a file name in string.")
@@ -1777,7 +1777,8 @@ class Cursor(object):
         It takes the number of rows to fetch as an argument.  If this
         is not provided it fetches self.arraysize number of rows.
         """
-        LogMsg(DEBUG, "Fetching %d rows from the database.", size)
+        message = "Fetching %d rows from the database." % size
+        LogMsg(DEBUG, message)
         if not isinstance(size, int_types):
             LogMsg(EXCEPTION, "fetchmany expects argument type int or long.")
             self.messages.append(InterfaceError("fetchmany expects argument type int or long."))

--- a/ibm_db_tests/test_312_FetchOne.py
+++ b/ibm_db_tests/test_312_FetchOne.py
@@ -1,0 +1,76 @@
+#
+#  Licensed Materials - Property of IBM
+#
+#  (c) Copyright IBM Corp. 2007-2008
+#
+
+from __future__ import print_function
+import sys
+import unittest
+import ibm_db
+import config
+from testfunctions import IbmDbTestFunctions
+
+class IbmDbTestCase(unittest.TestCase):
+    
+    def test_312_FetchOne(self):
+        obj = IbmDbTestFunctions()
+        obj.assert_expect(self.run_test_312)
+
+    def run_test_312(self):
+        conn = ibm_db.connect(config.database, config.user, config.password)
+
+        ibm_db.autocommit(conn, ibm_db.SQL_AUTOCOMMIT_OFF)
+
+        # Drop the test table, in case it exists
+        drop = 'DROP TABLE animals'
+        try:
+            result = ibm_db.exec_immediate(conn, drop)
+        except:
+            pass
+
+        # Create the test table
+        create = 'CREATE TABLE animals (id INTEGER, breed VARCHAR(32), name VARCHAR(16), weight DECIMAL(7,2))'
+        result = ibm_db.exec_immediate(conn, create)
+        
+        insert = "INSERT INTO animals values (0, 'cat', 'Pook', 3.2)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (1, 'dog', 'Max', 12.5)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (2, 'parrot', 'Polly', 0.8)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (3, 'rabbit', 'Bunny', 2.3)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (4, 'hamster', 'Nibbles', 0.5)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (5, 'fish', 'Bubbles', 0.2)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (6, 'snake', 'Slither', 1.1)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (7, 'horse', 'Thunder', 450.7)"
+        ibm_db.exec_immediate(conn, insert)
+
+        stmt = ibm_db.exec_immediate(conn, "select * from animals")
+
+        onerow = ibm_db.fetchone(stmt)
+
+        print(onerow)
+
+        ibm_db.rollback(conn)
+
+#__END__
+#__LUW_EXPECTED__
+#(0, 'cat', 'Pook', '3.20')
+#__ZOS_EXPECTED__
+#(0, 'cat', 'Pook', '3.20')
+#__SYSTEMI_EXPECTED__
+#(0, 'cat', 'Pook', '3.20')
+#__IDS_EXPECTED__
+#(0, 'cat', 'Pook', '3.20')

--- a/ibm_db_tests/test_313_FetchMany.py
+++ b/ibm_db_tests/test_313_FetchMany.py
@@ -1,0 +1,76 @@
+#
+#  Licensed Materials - Property of IBM
+#
+#  (c) Copyright IBM Corp. 2007-2008
+#
+
+from __future__ import print_function
+import sys
+import unittest
+import ibm_db
+import config
+from testfunctions import IbmDbTestFunctions
+
+class IbmDbTestCase(unittest.TestCase):
+    
+    def test_313_FetchMany(self):
+        obj = IbmDbTestFunctions()
+        obj.assert_expect(self.run_test_313)
+
+    def run_test_313(self):
+        conn = ibm_db.connect(config.database, config.user, config.password)
+
+        ibm_db.autocommit(conn, ibm_db.SQL_AUTOCOMMIT_OFF)
+
+        # Drop the test table, in case it exists
+        drop = 'DROP TABLE animals'
+        try:
+            result = ibm_db.exec_immediate(conn, drop)
+        except:
+            pass
+
+        # Create the test table
+        create = 'CREATE TABLE animals (id INTEGER, breed VARCHAR(32), name VARCHAR(16), weight DECIMAL(7,2))'
+        result = ibm_db.exec_immediate(conn, create)
+        
+        insert = "INSERT INTO animals values (0, 'cat', 'Pook', 3.2)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (1, 'dog', 'Max', 12.5)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (2, 'parrot', 'Polly', 0.8)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (3, 'rabbit', 'Bunny', 2.3)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (4, 'hamster', 'Nibbles', 0.5)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (5, 'fish', 'Bubbles', 0.2)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (6, 'snake', 'Slither', 1.1)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (7, 'horse', 'Thunder', 450.7)"
+        ibm_db.exec_immediate(conn, insert)
+
+        stmt = ibm_db.exec_immediate(conn, "select * from animals")
+
+        rows = ibm_db.fetchmany(stmt,2)
+
+        print(rows)
+
+        ibm_db.rollback(conn)
+
+#__END__
+#__LUW_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50')]
+#__ZOS_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50')]
+#__SYSTEMI_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50')]
+#__IDS_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50')]

--- a/ibm_db_tests/test_314_FetchAll.py
+++ b/ibm_db_tests/test_314_FetchAll.py
@@ -1,0 +1,76 @@
+#
+#  Licensed Materials - Property of IBM
+#
+#  (c) Copyright IBM Corp. 2007-2008
+#
+
+from __future__ import print_function
+import sys
+import unittest
+import ibm_db
+import config
+from testfunctions import IbmDbTestFunctions
+
+class IbmDbTestCase(unittest.TestCase):
+    
+    def test_314_FetchAll(self):
+        obj = IbmDbTestFunctions()
+        obj.assert_expect(self.run_test_314)
+
+    def run_test_314(self):
+        conn = ibm_db.connect(config.database, config.user, config.password)
+
+        ibm_db.autocommit(conn, ibm_db.SQL_AUTOCOMMIT_OFF)
+
+        # Drop the test table, in case it exists
+        drop = 'DROP TABLE animals'
+        try:
+            result = ibm_db.exec_immediate(conn, drop)
+        except:
+            pass
+
+        # Create the test table
+        create = 'CREATE TABLE animals (id INTEGER, breed VARCHAR(32), name VARCHAR(16), weight DECIMAL(7,2))'
+        result = ibm_db.exec_immediate(conn, create)
+        
+        insert = "INSERT INTO animals values (0, 'cat', 'Pook', 3.2)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (1, 'dog', 'Max', 12.5)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (2, 'parrot', 'Polly', 0.8)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (3, 'rabbit', 'Bunny', 2.3)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (4, 'hamster', 'Nibbles', 0.5)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (5, 'fish', 'Bubbles', 0.2)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (6, 'snake', 'Slither', 1.1)"
+        ibm_db.exec_immediate(conn, insert)
+        
+        insert = "INSERT INTO animals values (7, 'horse', 'Thunder', 450.7)"
+        ibm_db.exec_immediate(conn, insert)
+
+        stmt = ibm_db.exec_immediate(conn, "select * from animals")
+
+        allRows = ibm_db.fetchall(stmt)
+
+        print(allRows)
+
+        ibm_db.rollback(conn)
+
+#__END__
+#__LUW_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50'), (2, 'parrot', 'Polly', '0.80'), (3, 'rabbit', 'Bunny', '2.30'), (4, 'hamster', 'Nibbles', '0.50'), (5, 'fish', 'Bubbles', '0.20'), (6, 'snake', 'Slither', '1.10'), (7, 'horse', 'Thunder', '450.70')]
+#__ZOS_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50'), (2, 'parrot', 'Polly', '0.80'), (3, 'rabbit', 'Bunny', '2.30'), (4, 'hamster', 'Nibbles', '0.50'), (5, 'fish', 'Bubbles', '0.20'), (6, 'snake', 'Slither', '1.10'), (7, 'horse', 'Thunder', '450.70')]
+#__SYSTEMI_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50'), (2, 'parrot', 'Polly', '0.80'), (3, 'rabbit', 'Bunny', '2.30'), (4, 'hamster', 'Nibbles', '0.50'), (5, 'fish', 'Bubbles', '0.20'), (6, 'snake', 'Slither', '1.10'), (7, 'horse', 'Thunder', '450.70')]
+#__IDS_EXPECTED__
+#[(0, 'cat', 'Pook', '3.20'), (1, 'dog', 'Max', '12.50'), (2, 'parrot', 'Polly', '0.80'), (3, 'rabbit', 'Bunny', '2.30'), (4, 'hamster', 'Nibbles', '0.50'), (5, 'fish', 'Bubbles', '0.20'), (6, 'snake', 'Slither', '1.10'), (7, 'horse', 'Thunder', '450.70')]

--- a/setup.py
+++ b/setup.py
@@ -534,6 +534,7 @@ setup( name    = PACKAGE,
                     'Programming Language :: Python :: 3.10',
                     'Programming Language :: Python :: 3.11',
                     'Programming Language :: Python :: 3.12',
+                    'Programming Language :: Python :: 3.13',
                     'Topic :: Database :: Front-Ends'],
 
     long_description = open(readme).read(),


### PR DESCRIPTION
This pull request introduces support for Python 3.13 and enhances the database interaction functionality by adding support for the following fetch APIs:

- fetchone: Retrieves a single row from the result set.
- fetchmany: Fetches a specified number of rows from the result set.
- fetchall: Retrieves all rows from the result set.

You can follow below example to use fetch APIs

```
stmt = ibm_db.exec_immediate(conn, "select * from animals")
rows = ibm_db.fetchall(stmt)
print(rows)

stmt1 = ibm_db.exec_immediate(conn, "select * from animals")
nRows = ibm_db.fetchmany(stmt1,2)
print(nRows)

stmt2 = ibm_db.exec_immediate(conn, "select * from animals")
firstRow = ibm_db.fetchone(stmt2)
print(firstRow)
```

[Py_UNICODE - Deprecated since version 3.13, will be removed in version 3.15. ](https://docs.python.org/3/c-api/unicode.html#c.Py_UNICODE) 
So used wchar_t in place of Py_UNICODE.


Bug Fixes:
  - Logging Enhancement: Removed the timestamp from the ibm_db logging part to streamline the logs.
  - ibm_db_dbi Bug Fix: Addressed a bug in the ibm_db_dbi module, ensuring proper functionality and stability.
  - Logging Improvements: Enhanced the logging functionality within the ibm_db_dbi module to improve traceability and 
  debugging.
