### PR TITLE
Resolve fetchall() does not return error even though the select statement should hit SQL0137N error

### DIFF
--- a/ibm_db.c
+++ b/ibm_db.c
@@ -15505,7 +15505,7 @@ static PyObject* ibm_db_fetchmany(PyObject *self, PyObject *args)
 // Fetch all rows from the result set
 static PyObject *ibm_db_fetchall(PyObject *self, PyObject *args)
 {
-    LogMsg(INFO, "entry fetchmany()", fileName);
+    LogMsg(INFO, "entry fetchall()", fileName);
     PyObject *argsStr = PyObject_Repr(args);  // Get string representation of args
     snprintf(messageStr, sizeof(messageStr), "Received arguments: %s", PyUnicode_AsUTF8(argsStr));
     LogMsg(INFO, messageStr, fileName);

--- a/ibm_db_dbi.py
+++ b/ibm_db_dbi.py
@@ -1792,15 +1792,11 @@ class Cursor(object):
                     error_msg = f"Statement error: {str(ibm_db.stmt_errormsg())}"
                     LogMsg(ERROR, error_msg)
                     self.messages.append(Error(str(ibm_db.stmt_errormsg())))
+                    raise self.messages[len(self.messages) - 1]
                 else:
                     LogMsg(ERROR, f"Error occured : {_get_exception(inst)}")
                     self.messages.append(_get_exception(inst))
-                if len(row_list) == 0:
                     raise self.messages[len(self.messages) - 1]
-                else:
-                    LogMsg(DEBUG, f"Returning {row_list} from _fetch_helper()")
-                    LogMsg(INFO, "exit _fetch_helper()")
-                    return row_list
 
             if row != False:
                 if self.FIX_RETURN_TYPE == 1:

--- a/ibm_db_tests/test_315_FetchAll_DBI.py
+++ b/ibm_db_tests/test_315_FetchAll_DBI.py
@@ -1,0 +1,73 @@
+#
+#  Licensed Materials - Property of IBM
+#
+#  (c) Copyright IBM Corp. 2007-2008
+#
+
+from __future__ import print_function
+import sys
+import unittest
+import ibm_db
+import ibm_db_dbi
+import config
+from testfunctions import IbmDbTestFunctions
+
+
+class IbmDbTestCase(unittest.TestCase):
+
+    def test_315_FetchAll_DBI(self):
+        obj = IbmDbTestFunctions()
+        obj.assert_expect(self.run_test_315)
+
+    def run_test_315(self):
+        conn = ibm_db.connect(config.database, config.user, config.password)
+
+        ibm_db.autocommit(conn, ibm_db.SQL_AUTOCOMMIT_OFF)
+
+        # Drop the test table, in case it exists
+        drop = 'DROP TABLE varigraph'
+        try:
+            result = ibm_db.exec_immediate(conn, drop)
+        except:
+            pass
+
+        # Create the test table
+        create = 'CREATE TABLE varigraph( i INT, g VARGRAPHIC(10000))'
+        result = ibm_db.exec_immediate(conn, create)
+
+        vargraphic_string = "a" * 8192
+
+        insert_sql = "INSERT INTO varigraph (i, g) VALUES (?, ?)"
+        stmt = ibm_db.prepare(conn, insert_sql)
+
+        ibm_db.bind_param(stmt, 1, 0)
+        ibm_db.bind_param(stmt, 2, 'hogehoge')
+        ibm_db.execute(stmt)
+
+        ibm_db.bind_param(stmt, 1, 1)
+        ibm_db.bind_param(stmt, 2, vargraphic_string)
+        ibm_db.execute(stmt)
+
+        db2_conn = ibm_db_dbi.Connection(conn)
+        db2_cur = db2_conn.cursor()
+
+        sql = "SELECT i, length(g||g) FROM varigraph"
+
+        try:
+            db2_conn.cursor()
+            db2_cur.execute(sql)
+            for (i, len) in db2_cur.fetchall():
+                print("i: {} , len: {} ".format(i, len))
+        except:
+            err = ibm_db.stmt_errormsg()
+            print(err)
+
+#__END__
+#__LUW_EXPECTED__
+#[IBM][CLI Driver][DB2/LINUXX8664] SQL0137N  The length resulting from "CONCAT" is greater than "0000016350 ".  SQLSTATE=54006  SQLCODE=-137
+#__ZOS_EXPECTED__
+#[IBM][CLI Driver][DB2/LINUXX8664] SQL0137N  The length resulting from "CONCAT" is greater than "0000016350 ".  SQLSTATE=54006  SQLCODE=-137
+#__SYSTEMI_EXPECTED__
+#[IBM][CLI Driver][AS] SQL0137N  The length resulting from "CONCAT" is greater than "0000016350 ".  SQLSTATE=54006  SQLCODE=-137
+#__IDS_EXPECTED__
+#[IBM][CLI Driver][IDS/LINUXX8664] SQL0137N  The length resulting from "CONCAT" is greater than "0000016350 ".  SQLSTATE=54006  SQLCODE=-137


### PR DESCRIPTION
Resolved issue for  fetchall() does not return error even though the select statement should hit SQL0137N error.
for the CRM - https://jira.rocketsoftware.com/browse/DBC-16605

This update modifies the behavior of the fetchall() method in the ibm_db_dbi module. From now on, if there is an error in any of the rows during the fetch operation, the method will raise an error instead of returning a list of rows that do not have any errors. This change ensures that any issues encountered while fetching data are promptly raised, rather than silently skipping over problematic rows.