### PR TITLE
Fix datetime with timezone regression  

### DIFF
--- a/ibm_db.c
+++ b/ibm_db.c
@@ -17181,17 +17181,25 @@ static int _python_get_variable_type(PyObject *variable_value)
 	{
         LogMsg(INFO, "variable_value is a datetime object");
         PyObject *tzinfo = PyObject_GetAttrString(variable_value, "tzinfo");
+
+#if defined(__MVS__)
         if (tzinfo && tzinfo != Py_None) {
             Py_DECREF(tzinfo);
-            LogMsg(INFO, "variable_value is a datetime object");
+            LogMsg(INFO, "datetime object has tzinfo on z/OS");
             LogMsg(INFO, "exit _python_get_variable_type() with PYTHON_TIMESTAMP_TSTZ");
             return PYTHON_TIMESTAMP_TSTZ;
         } else {
             Py_XDECREF(tzinfo);
-            LogMsg(INFO, "variable_value is a datetime object");
+            LogMsg(INFO, "datetime object has no tzinfo on z/OS");
             LogMsg(INFO, "exit _python_get_variable_type() with PYTHON_TIMESTAMP");
             return PYTHON_TIMESTAMP;
         }
+#else
+        Py_XDECREF(tzinfo);
+        LogMsg(INFO, "datetime object on LUW (tzinfo ignored)");
+        LogMsg(INFO, "exit _python_get_variable_type() with PYTHON_TIMESTAMP");
+        return PYTHON_TIMESTAMP;
+#endif
     }
     else if (PyTime_Check(variable_value))
     {


### PR DESCRIPTION
Support for TIMESTAMP WITH TIME ZONE was added in the last release for z/OS.  
After this change, inserting timezone‑aware datetime values on LUW resulted in
overflow errors because the timezone part was being processed even though LUW
does not support TIMESTAMP WITH TIME ZONE natively.

The timezone part should not be applied for LUW. When processing datetime objects with tzinfo gives datetime overflow error.
And for zos,  timestamp case timezone part should ignored. For timestamp with timezone case datetime with timezone processed.

Added fix that timezone part should be ignored for luw and should not throw error datetime overflow error. 

#1030 
